### PR TITLE
Show file metadata next to media previews

### DIFF
--- a/src/app/asset/asset.service.ts
+++ b/src/app/asset/asset.service.ts
@@ -372,7 +372,9 @@ export class AssetService extends EventEmitter<AssetEvents> {
       ? entity.metadata[titleField.id]?.[0]
       : undefined;
 
-    return archive.useDb(async (): Promise<Asset> => {
+    return archive.useDb(async (db): Promise<Asset> => {
+      await db.populate(entity, ['mediaFiles']);
+
       return {
         id: entity.id,
         title: typeof titleValue === 'string' ? titleValue : entity.id,

--- a/src/app/asset/asset.service.ts
+++ b/src/app/asset/asset.service.ts
@@ -378,12 +378,10 @@ export class AssetService extends EventEmitter<AssetEvents> {
         title: typeof titleValue === 'string' ? titleValue : entity.id,
         media: shallow
           ? []
-          : Array.from(entity.mediaFiles).map((file) => ({
-              id: file.id,
-              type: 'image',
-              rendition: this.mediaService.getRenditionUri(archive, file),
-              mimeType: file.mimeType
-            })),
+          : await this.mediaService.getMedia(
+              archive,
+              entity.mediaFiles.getIdentifiers()
+            ),
         metadata: shallow
           ? {}
           : Object.fromEntries(

--- a/src/app/ingest/asset-ingest.service.ts
+++ b/src/app/ingest/asset-ingest.service.ts
@@ -134,30 +134,25 @@ export class AssetIngestService extends EventEmitter<Events> {
 
     return {
       ...res,
-      items: res.items.map((entity) => ({
-        id: entity.id,
-        title: entity.id,
-        metadata: mapValues(entity.metadata, (rawValue) => ({
-          rawValue,
-          presentationValue: rawValue.map((x) => ({
-            label: String(x),
-            rawValue: x
-          }))
-        })),
-        phase: entity.phase,
-        validationErrors: entity.validationErrors,
-        media: compact(
-          entity.files.getItems().map(
-            ({ media }) =>
-              media && {
-                id: media.id,
-                mimeType: media.mimeType,
-                rendition: this.mediaService.getRenditionUri(archive, media),
-                type: 'image'
-              }
+      items: await Promise.all(
+        res.items.map(async (entity) => ({
+          id: entity.id,
+          title: entity.id,
+          metadata: mapValues(entity.metadata, (rawValue) => ({
+            rawValue,
+            presentationValue: rawValue.map((x) => ({
+              label: String(x),
+              rawValue: x
+            }))
+          })),
+          phase: entity.phase,
+          validationErrors: entity.validationErrors,
+          media: await this.mediaService.getMedia(
+            archive,
+            entity.files.getIdentifiers()
           )
-        )
-      }))
+        }))
+      )
     };
   }
 

--- a/src/common/media.interfaces.ts
+++ b/src/common/media.interfaces.ts
@@ -7,7 +7,8 @@ export const ImageMedia = z.object({
   id: z.string(),
   type: z.literal('image'),
   rendition: z.string(),
-  mimeType: z.string()
+  mimeType: z.string(),
+  fileSize: z.number()
 });
 
 /**

--- a/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
+++ b/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
@@ -142,13 +142,15 @@ const MEDIA_FILES: Media[] = [
     id: '1',
     type: 'image',
     mimeType: 'image/png',
-    rendition: require('./media/a.png')
+    rendition: require('./media/a.png'),
+    fileSize: 100
   },
   {
     id: '2',
     type: 'image',
     mimeType: 'image/jpeg',
-    rendition: require('./media/b.jpg')
+    rendition: require('./media/b.jpg'),
+    fileSize: 100
   }
 ];
 

--- a/src/frontend/ui/components/asset-detail.component.tsx
+++ b/src/frontend/ui/components/asset-detail.component.tsx
@@ -203,11 +203,16 @@ export const AssetDetail: FC<MediaDetailProps> = ({
               }}
             >
               {asset.media.map((item) => (
-                <Image
-                  sx={{ '&:not(:first-of-type)': { mt: 3 } }}
-                  key={item.id}
-                  src={item.rendition}
-                />
+                <Box sx={{ '&:not(:first-of-type)': { mt: 3 } }}>
+                  <Image key={item.id} src={item.rendition} />
+                  <Text sx={{ textTransform: 'capitalize', fontSize: 1 }}>
+                    {item.mimeType.split('/')[0]} ({item.mimeType.split('/')[1]}
+                    )
+                    <Text sx={{ float: 'right' }}>
+                      {megabytes(item.fileSize)}MB
+                    </Text>
+                  </Text>{' '}
+                </Box>
               ))}
             </Flex>
           </IconTab>
@@ -280,4 +285,11 @@ export const AssetDetail: FC<MediaDetailProps> = ({
       </Flex>
     </Flex>
   );
+};
+
+const megabytes = (bytes: number, precision = 2) => {
+  const mb = bytes / 1024 / 1024;
+  const factor = 10 ** precision;
+
+  return Math.floor(mb * factor) / factor;
 };


### PR DESCRIPTION
Shows file metadata (currently format and file size) next to preview images in the asset detail view.

In the process, we slightly tidy up the interface between the asset and media domains and move some logic over to media.