### PR TITLE
Adds support for repeated properties in schema

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,7 +5,7 @@ on:
     branch: [main]
 
 jobs:
-  release:
+  test_and_lint:
     runs-on: ubuntu-latest
 
     steps:

--- a/src/app/asset/__tests__/asset.spec.ts
+++ b/src/app/asset/__tests__/asset.spec.ts
@@ -23,6 +23,13 @@ const SCHEMA: SchemaProperty[] = [
     type: SchemaPropertyType.FREE_TEXT,
     repeated: false,
     required: true
+  },
+  {
+    id: 'repeatedProperty',
+    label: 'Some Property',
+    type: SchemaPropertyType.FREE_TEXT,
+    repeated: true,
+    required: false
   }
 ];
 
@@ -40,8 +47,9 @@ describe(AssetService, () => {
         fixture.rootCollection.id,
         {
           metadata: {
-            requiredProperty: '1',
-            optionalProperty: '2',
+            requiredProperty: ['1'],
+            optionalProperty: ['2'],
+            repeatedProperty: ['3', '4'],
             unknownProperty: 'No'
           }
         }
@@ -65,8 +73,9 @@ describe(AssetService, () => {
         items: [
           expect.objectContaining({
             metadata: {
-              requiredProperty: '1',
-              optionalProperty: '2'
+              requiredProperty: ['1'],
+              optionalProperty: ['2'],
+              repeatedProperty: ['3', '4']
             }
           })
         ]
@@ -80,7 +89,7 @@ describe(AssetService, () => {
 
     await fixture.service.updateAsset(fixture.archive, asset.id, {
       metadata: {
-        requiredProperty: 'Replace'
+        requiredProperty: ['Replace']
       }
     });
 
@@ -100,7 +109,7 @@ describe(AssetService, () => {
         items: [
           expect.objectContaining({
             metadata: {
-              requiredProperty: 'Replace'
+              requiredProperty: ['Replace']
             }
           })
         ]
@@ -136,7 +145,7 @@ describe(AssetService, () => {
         fixture.rootCollection.id,
         {
           metadata: {
-            requiredProperty: '1'
+            requiredProperty: ['1']
           }
         }
       )

--- a/src/app/asset/__tests__/asset.spec.ts
+++ b/src/app/asset/__tests__/asset.spec.ts
@@ -51,7 +51,7 @@ describe(AssetService, () => {
             requiredProperty: ['1'],
             optionalProperty: ['2'],
             repeatedProperty: ['3', '4'],
-            unknownProperty: 'No'
+            unknownProperty: ['No']
           }
         }
       )

--- a/src/app/asset/__tests__/asset.spec.ts
+++ b/src/app/asset/__tests__/asset.spec.ts
@@ -14,12 +14,14 @@ const SCHEMA: SchemaProperty[] = [
     id: 'optionalProperty',
     label: 'Optional Property',
     type: SchemaPropertyType.FREE_TEXT,
+    repeated: false,
     required: false
   },
   {
     id: 'requiredProperty',
     label: 'Some Property',
     type: SchemaPropertyType.FREE_TEXT,
+    repeated: false,
     required: true
   }
 ];

--- a/src/app/asset/__tests__/collection.spec.ts
+++ b/src/app/asset/__tests__/collection.spec.ts
@@ -24,6 +24,7 @@ describe(CollectionService, () => {
         id: 'dogtype',
         label: 'Dog Type',
         required: true,
+        repeated: false,
         type: SchemaPropertyType.FREE_TEXT
       }
     ]);
@@ -82,6 +83,7 @@ describe(CollectionService, () => {
           id: 'dogtype',
           label: 'Dog Type',
           required: false,
+          repeated: false,
           type: SchemaPropertyType.FREE_TEXT
         }
       ])
@@ -101,6 +103,7 @@ describe(CollectionService, () => {
           id: 'dogtype',
           label: 'Dog Type',
           required: true,
+          repeated: false,
           type: SchemaPropertyType.FREE_TEXT
         }
       ]
@@ -121,6 +124,7 @@ describe(CollectionService, () => {
           id: 'dogtype',
           label: 'Dog Type',
           required: true,
+          repeated: false,
           type: SchemaPropertyType.FREE_TEXT
         }
       ]
@@ -142,6 +146,7 @@ describe(CollectionService, () => {
               id: 'title',
               label: 'Title',
               type: SchemaPropertyType.FREE_TEXT,
+              repeated: false,
               required: true
             }
           ]
@@ -157,6 +162,7 @@ describe(CollectionService, () => {
             label: 'Database Reference',
             type: SchemaPropertyType.CONTROLLED_DATABASE,
             databaseId: db.id,
+            repeated: false,
             required: true
           }
         ]

--- a/src/app/asset/__tests__/collection.spec.ts
+++ b/src/app/asset/__tests__/collection.spec.ts
@@ -36,13 +36,13 @@ describe(CollectionService, () => {
         {
           id: 'myLab',
           metadata: {
-            dogtype: 'Labrador'
+            dogtype: ['Labrador']
           }
         },
         {
           id: 'myPoodle',
           metadata: {
-            dogtype: 'Poodle'
+            dogtype: ['Poodle']
           }
         },
         {
@@ -56,12 +56,12 @@ describe(CollectionService, () => {
       expect.arrayContaining([
         {
           id: 'myLab',
-          metadata: { dogtype: 'Labrador' },
+          metadata: { dogtype: ['Labrador'] },
           success: true
         },
         {
           id: 'myPoodle',
-          metadata: { dogtype: 'Poodle' },
+          metadata: { dogtype: ['Poodle'] },
           success: true
         },
         {
@@ -112,7 +112,7 @@ describe(CollectionService, () => {
 
     requireSuccess(
       await fixture.assets.updateAsset(fixture.archive, testAsset.id, {
-        metadata: { dogtype: 'Husky' }
+        metadata: { dogtype: ['Husky'] }
       })
     );
 
@@ -178,7 +178,7 @@ describe(CollectionService, () => {
       const dbRecord = requireSuccess(
         await fixture.assets.createAsset(fixture.archive, db.id, {
           metadata: {
-            title: 'My Database Record'
+            title: ['My Database Record']
           }
         })
       );
@@ -188,7 +188,7 @@ describe(CollectionService, () => {
         fixture.assetCollection.id,
         {
           metadata: {
-            dbRef: dbRecord.id
+            dbRef: [dbRecord.id]
           }
         }
       );

--- a/src/app/asset/__tests__/collection.spec.ts
+++ b/src/app/asset/__tests__/collection.spec.ts
@@ -205,7 +205,7 @@ describe(CollectionService, () => {
         fixture.assetCollection.id,
         {
           metadata: {
-            dbRef: 'this is not a valid id'
+            dbRef: ['this is not a valid id']
           }
         }
       );

--- a/src/app/asset/asset.entity.ts
+++ b/src/app/asset/asset.entity.ts
@@ -113,6 +113,6 @@ export class AssetCollectionEntity {
       !!titleProperty &&
       this.schema.every((x) => !x.required || x.id === titleProperty.id);
 
-    return canBeLabelRecord ? { [titleProperty.id]: title } : undefined;
+    return canBeLabelRecord ? { [titleProperty.id]: [title] } : undefined;
   }
 }

--- a/src/app/asset/asset.entity.ts
+++ b/src/app/asset/asset.entity.ts
@@ -39,7 +39,7 @@ export class AssetEntity {
    * Key-value metadata properties. Keys are the id of schema property
    */
   @Property({ type: 'json', nullable: false })
-  metadata: Dict = {};
+  metadata: Dict<unknown[]> = {};
 }
 
 /**

--- a/src/app/asset/asset.service.ts
+++ b/src/app/asset/asset.service.ts
@@ -192,7 +192,7 @@ export class AssetService extends EventEmitter<AssetEvents> {
         }
       );
 
-      return {
+      const result = {
         ...entities,
         items: await Promise.all(
           entities.items.map(async (entity) =>
@@ -200,6 +200,8 @@ export class AssetService extends EventEmitter<AssetEvents> {
           )
         )
       };
+
+      return result;
     });
   }
 

--- a/src/app/asset/asset.service.ts
+++ b/src/app/asset/asset.service.ts
@@ -282,10 +282,26 @@ export class AssetService extends EventEmitter<AssetEvents> {
     });
   }
 
+  /**
+   * Get a single asset by ID from the archive
+   *
+   * @param archive Archive to get asset from
+   * @param asset Id of the asset
+   * @param opts Options for fetching the asset
+   * @returns The asset represented by `id`, or undefined if it does not exist.
+   */
   get(archive: ArchivePackage, asset: string, opts?: GetAssetOpts) {
     return this.getMultiple(archive, [asset], opts).then((assets) => assets[0]);
   }
 
+  /**
+   * Get a multiple assets by ID from the archive
+   *
+   * @param archive Archive to get assets from
+   * @param asset Ids of the assets to fetch
+   * @param opts Options for fetching the asset
+   * @returns Array containing any referenced assets found.
+   */
   getMultiple(
     archive: ArchivePackage,
     assetIds: string[],
@@ -308,6 +324,18 @@ export class AssetService extends EventEmitter<AssetEvents> {
       );
   }
 
+  /**
+   * Cast a value of unknown type to the type expected by the schema property.
+   *
+   * If this succeeds, the returned value is valid according to the the schema at the time of casting.
+   *
+   * This method may have side effects, such as creating new entries in a controlled database.
+   *
+   * @param archive Archive that owns `property`
+   * @param property Property value representing the expected type
+   * @param value Value to cast to the type represented by `value`
+   * @returns A result value indicating whether the cast was successful and if so, the casted value.
+   */
   castOrCreateProperty(
     archive: ArchivePackage,
     property: SchemaProperty,
@@ -320,6 +348,17 @@ export class AssetService extends EventEmitter<AssetEvents> {
     });
   }
 
+  /**
+   * Convert a database entity representing to an Asset value sutable for returning to the frontend or passing to other
+   * areas of the application.
+   *
+   * This recurses into the asset's related properties and media in order to provide useful
+   *
+   * @param archive
+   * @param entity
+   * @param opts
+   * @returns
+   */
   private entityToAsset(
     archive: ArchivePackage,
     entity: AssetEntity,
@@ -368,6 +407,12 @@ export class AssetService extends EventEmitter<AssetEvents> {
 }
 
 interface GetAssetOpts {
+  /**
+   * If false, recurse into the asset, fetching related media and metadata from the database (default is false).
+   *
+   * This will usually want to be false, except in contexts where a related property is being fetched and you want to
+   * avoid an infinite recursion.
+   **/
   shallow?: boolean;
 }
 

--- a/src/app/asset/collection.service.ts
+++ b/src/app/asset/collection.service.ts
@@ -410,7 +410,7 @@ interface CollectionEvents {
 }
 
 type ValidateItemsResult =
-  | { success: true; id: string; metadata: Dict }
+  | { success: true; id: string; metadata: Dict<unknown[]> }
   | { success: false; id: string; errors: Dict<string[]> };
 
 type CreateCollectionOpts = Pick<Collection, 'schema' | 'title'>;

--- a/src/app/asset/metadata.entity.ts
+++ b/src/app/asset/metadata.entity.ts
@@ -94,18 +94,10 @@ export abstract class SchemaPropertyValue {
   /**
    * Override to provide a display value for the
    */
-  async convertToMetadataItems(
+  abstract convertToMetadataItems(
     context: AssetContext,
     value: unknown[]
-  ): Promise<AssetMetadataItem> {
-    return {
-      rawValue: value,
-      presentationValue: value.map((rawValue) => ({
-        rawValue,
-        label: String(rawValue)
-      }))
-    };
-  }
+  ): Promise<AssetMetadataItem>;
 
   /**
    * Return a zod validator object for this schema property.
@@ -183,6 +175,19 @@ export class FreeTextSchemaPropertyValue
 
   toJson() {
     return this;
+  }
+
+  async convertToMetadataItems(
+    context: AssetContext,
+    value: unknown[]
+  ): Promise<AssetMetadataItem<unknown>> {
+    return {
+      rawValue: value,
+      presentationValue: value.map((rawValue) => ({
+        rawValue,
+        label: String(rawValue)
+      }))
+    };
   }
 }
 

--- a/src/app/asset/metadata.entity.ts
+++ b/src/app/asset/metadata.entity.ts
@@ -83,16 +83,8 @@ export abstract class SchemaPropertyValue {
   repeated!: boolean;
 
   /**
-   * Override to define collections referenced by this property. Defaults to none.
-   *
-   * @returns The id of a referenced collection or undefined if none.
-   */
-  getReferencedCollection(): string | undefined {
-    return undefined;
-  }
-
-  /**
-   * Override to provide a display value for the
+   * Override to define how raw values in the database are converted into `AssetMetadataItem` values for presentation
+   * in the UI
    */
   abstract convertToMetadataItems(
     context: AssetContext,
@@ -282,10 +274,6 @@ export class ControlledDatabaseSchemaPropertyValue
 
   toJson() {
     return this;
-  }
-
-  getReferencedCollection(): string | undefined {
-    return this.databaseId;
   }
 
   async convertToMetadataItems(

--- a/src/app/asset/metadata.entity.ts
+++ b/src/app/asset/metadata.entity.ts
@@ -45,6 +45,12 @@ export abstract class SchemaPropertyValue {
     }
   }
 
+  constructor() {
+    if (typeof this.repeated === 'undefined') {
+      this.repeated = false;
+    }
+  }
+
   /**
    * Id of the property. This will be the key used to record metadata values in an asset.
    */
@@ -67,7 +73,13 @@ export abstract class SchemaPropertyValue {
    * True if the property is required.
    */
   @Property({ type: 'boolean' })
-  required!: boolean;
+  required = false;
+
+  /**
+   * True if the property supports multiple occurances.
+   */
+  @Property({ type: 'boolean', default: true })
+  repeated!: boolean;
 
   /**
    * Override to define collections referenced by this property. Defaults to none.

--- a/src/app/asset/metadata.entity.ts
+++ b/src/app/asset/metadata.entity.ts
@@ -94,12 +94,17 @@ export abstract class SchemaPropertyValue {
    * Return a zod validator object for this schema property.
    */
   async getValidator(context: CollectionContext) {
-    if (!this.required) {
-      const innerSchema = await this.getValueSchema(context);
-      return innerSchema.optional();
+    let schema = z.array(await this.getValueSchema(context));
+
+    if (!this.repeated) {
+      schema = schema.max(1);
     }
 
-    return this.getValueSchema(context);
+    if (this.required) {
+      return schema.min(1);
+    } else {
+      return schema.optional();
+    }
   }
 
   /**

--- a/src/app/asset/test-utils.ts
+++ b/src/app/asset/test-utils.ts
@@ -1,0 +1,55 @@
+import faker from '@faker-js/faker';
+import { mapValues, times } from 'lodash';
+import {
+  Asset,
+  AssetMetadata,
+  AssetMetadataItem,
+  SchemaProperty,
+  SchemaPropertyType
+} from '../../common/asset.interfaces';
+import { never } from '../../common/util/assert';
+import { Dict } from '../../common/util/types';
+
+export const someAsset = (props: Partial<Asset> = {}): Asset => ({
+  id: faker.datatype.uuid(),
+  media: [],
+  metadata: {},
+  title: faker.word.noun(),
+  ...props
+});
+
+export const somePropertyFromASchema = (
+  schema: SchemaProperty
+): AssetMetadataItem => {
+  if (schema.repeated) {
+    return {
+      rawValue: times(
+        3,
+        () => somePropertyFromASchema({ ...schema, repeated: false }).rawValue
+      ).flat()
+    };
+  }
+
+  if (schema.type === SchemaPropertyType.FREE_TEXT) {
+    return {
+      rawValue: [faker.lorem.words(10)]
+    };
+  }
+
+  if (schema.type === SchemaPropertyType.CONTROLLED_DATABASE) {
+    return {
+      rawValue: [faker.datatype.uuid()]
+    };
+  }
+
+  return never(schema);
+};
+
+export const someMetadata = (schema: SchemaProperty[]): AssetMetadata =>
+  Object.fromEntries(
+    schema.map((property) => [property.id, somePropertyFromASchema(property)])
+  );
+
+export const assetMetadataFromRawValues = (
+  rawValues: Dict<unknown[]>
+): AssetMetadata => mapValues(rawValues, (rawValue) => ({ rawValue }));

--- a/src/app/asset/test-utils.ts
+++ b/src/app/asset/test-utils.ts
@@ -22,23 +22,28 @@ export const somePropertyFromASchema = (
   schema: SchemaProperty
 ): AssetMetadataItem => {
   if (schema.repeated) {
-    return {
-      rawValue: times(
+    return assetMetadataItem(
+      times(
         3,
         () => somePropertyFromASchema({ ...schema, repeated: false }).rawValue
       ).flat()
-    };
+    );
   }
 
   if (schema.type === SchemaPropertyType.FREE_TEXT) {
+    const val = faker.lorem.words(10);
     return {
-      rawValue: [faker.lorem.words(10)]
+      rawValue: [val],
+      presentationValue: [{ rawValue: val, label: val }]
     };
   }
 
   if (schema.type === SchemaPropertyType.CONTROLLED_DATABASE) {
+    const val = faker.datatype.uuid();
+
     return {
-      rawValue: [faker.datatype.uuid()]
+      rawValue: [val],
+      presentationValue: [{ label: faker.word.noun(), rawValue: val }]
     };
   }
 
@@ -50,6 +55,13 @@ export const someMetadata = (schema: SchemaProperty[]): AssetMetadata =>
     schema.map((property) => [property.id, somePropertyFromASchema(property)])
   );
 
-export const assetMetadataFromRawValues = (
-  rawValues: Dict<unknown[]>
-): AssetMetadata => mapValues(rawValues, (rawValue) => ({ rawValue }));
+export const assetMetadata = (rawValues: Dict<unknown[]>): AssetMetadata =>
+  mapValues(rawValues, assetMetadataItem);
+
+export const assetMetadataItem = (rawValue: unknown[]): AssetMetadataItem => ({
+  rawValue,
+  presentationValue: rawValue.map((val) => ({
+    rawValue: val,
+    label: String(val)
+  }))
+});

--- a/src/app/electron/router.ts
+++ b/src/app/electron/router.ts
@@ -64,10 +64,15 @@ export class ElectronRouter {
           };
         }
 
-        return {
-          status: 'ok',
-          value: descriptor.response.parse(response.value)
-        };
+        try {
+          return {
+            status: 'ok',
+            value: descriptor.response.parse(response.value)
+          };
+        } catch (error) {
+          console.error('Error encoding response in', descriptor.id, error);
+          throw new Error('Unexpected response');
+        }
       }
     );
   }

--- a/src/app/ingest/__tests__/asset-import.spec.ts
+++ b/src/app/ingest/__tests__/asset-import.spec.ts
@@ -256,8 +256,8 @@ describe('AssetImportOperation', () => {
     expect(assets.items.map((item) => item.media)).toHaveLength(2);
     expect(assets.items).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ metadata: { p: 'value1' } }),
-        expect.objectContaining({ metadata: { p: 'value2' } })
+        expect.objectContaining({ metadata: { p: ['value1'] } }),
+        expect.objectContaining({ metadata: { p: ['value2'] } })
       ])
     );
 

--- a/src/app/ingest/__tests__/asset-import.spec.ts
+++ b/src/app/ingest/__tests__/asset-import.spec.ts
@@ -37,6 +37,7 @@ describe('AssetImportOperation', () => {
         type: SchemaPropertyType.FREE_TEXT,
         id: 'internalPropertyId',
         label: 'property',
+        repeated: false,
         required: true
       }
     ]);
@@ -67,6 +68,7 @@ describe('AssetImportOperation', () => {
       {
         type: SchemaPropertyType.FREE_TEXT,
         id: 'missingProperty',
+        repeated: false,
         label: 'not there',
         required: true
       }
@@ -230,6 +232,7 @@ describe('AssetImportOperation', () => {
       {
         label: 'property',
         id: 'p',
+        repeated: false,
         type: SchemaPropertyType.FREE_TEXT,
         required: true
       }

--- a/src/app/ingest/__tests__/asset-import.spec.ts
+++ b/src/app/ingest/__tests__/asset-import.spec.ts
@@ -1,4 +1,4 @@
-import { compact } from 'lodash';
+import { compact, mapValues } from 'lodash';
 import path from 'path';
 import {
   SchemaProperty,
@@ -6,15 +6,14 @@ import {
 } from '../../../common/asset.interfaces';
 
 import { IngestPhase } from '../../../common/ingest.interfaces';
-import { error, ok, Result } from '../../../common/util/error';
-import { MaybeAsync } from '../../../common/util/types';
+import { error, ok } from '../../../common/util/error';
 import { collectEvents, waitUntilEvent } from '../../../test/event';
 import { getTempfiles, getTempPackage } from '../../../test/tempfile';
 import { AssetsChangedEvent, AssetService } from '../../asset/asset.service';
 import { CollectionService } from '../../asset/collection.service';
+import { assetMetadata, assetMetadataItem } from '../../asset/test-utils';
 import { MediaFile } from '../../media/media-file.entity';
 import { MediaFileService } from '../../media/media-file.service';
-import { ArchivePackage } from '../../package/archive-package';
 import {
   AssetImportEntity,
   FileImport,
@@ -256,8 +255,8 @@ describe('AssetImportOperation', () => {
     expect(assets.items.map((item) => item.media)).toHaveLength(2);
     expect(assets.items).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ metadata: { p: ['value1'] } }),
-        expect.objectContaining({ metadata: { p: ['value2'] } })
+        expect.objectContaining({ metadata: assetMetadata({ p: ['value1'] }) }),
+        expect.objectContaining({ metadata: assetMetadata({ p: ['value2'] }) })
       ])
     );
 
@@ -274,13 +273,15 @@ describe('AssetImportOperation', () => {
         label: 'property',
         id: 'p',
         type: SchemaPropertyType.FREE_TEXT,
-        required: true
+        required: true,
+        repeated: true
       },
       {
         label: 'extraProperty',
         id: 'extra',
         type: SchemaPropertyType.FREE_TEXT,
-        required: true
+        required: true,
+        repeated: true
       }
     ]);
 
@@ -295,8 +296,8 @@ describe('AssetImportOperation', () => {
     const sessionsEmittingEdit = fixture.editEvents((e) => e.session);
     for (const asset of assets.items) {
       await session.updateImportedAsset(asset.id, {
-        ...asset.metadata,
-        extra: 'Some Value'
+        ...mapValues(asset.metadata, (x) => x.rawValue),
+        extra: ['Some Value']
       });
     }
 
@@ -317,13 +318,15 @@ describe('AssetImportOperation', () => {
         label: 'property',
         id: 'p',
         type: SchemaPropertyType.FREE_TEXT,
-        required: true
+        required: true,
+        repeated: true
       },
       {
         label: 'extraProperty',
         id: 'extra',
         type: SchemaPropertyType.FREE_TEXT,
-        required: true
+        required: true,
+        repeated: true
       }
     ]);
 
@@ -339,13 +342,15 @@ describe('AssetImportOperation', () => {
           label: 'property',
           id: 'p',
           type: SchemaPropertyType.FREE_TEXT,
-          required: true
+          required: true,
+          repeated: true
         },
         {
           label: 'extraProperty',
           id: 'extra',
           type: SchemaPropertyType.FREE_TEXT,
-          required: false
+          required: false,
+          repeated: true
         }
       ]
     );
@@ -364,7 +369,8 @@ describe('AssetImportOperation', () => {
           label: 'property',
           id: 'property',
           type: SchemaPropertyType.FREE_TEXT,
-          required: true
+          required: true,
+          repeated: true
         }
       ]
     );
@@ -383,8 +389,8 @@ describe('AssetImportOperation', () => {
       session.id
     );
 
-    expect(assets.items.map((item) => item.metadata.property)).toContain(
-      'VALUE1'
+    expect(assets.items.map((item) => item.metadata.property)).toContainEqual(
+      assetMetadataItem(['VALUE1'])
     );
   });
 
@@ -398,7 +404,8 @@ describe('AssetImportOperation', () => {
           label: 'property',
           id: 'property',
           type: SchemaPropertyType.FREE_TEXT,
-          required: true
+          required: true,
+          repeated: true
         }
       ]
     );
@@ -411,8 +418,8 @@ describe('AssetImportOperation', () => {
       session.id
     );
 
-    expect(assets.items.map((item) => item.metadata.property)).toContain(
-      'value1'
+    expect(assets.items.map((item) => item.metadata.property)).toContainEqual(
+      assetMetadataItem(['value1'])
     );
   });
 });

--- a/src/app/ingest/asset-import.entity.ts
+++ b/src/app/ingest/asset-import.entity.ts
@@ -59,7 +59,7 @@ export class AssetImportEntity {
 
   /** Raw metadata discovered for the asset */
   @Property({ type: 'json' })
-  metadata!: Record<string, unknown>;
+  metadata!: Record<string, unknown[]>;
 
   /** Any validation errors */
   @Property({ type: 'json', nullable: true })

--- a/src/app/ingest/asset-ingest.operation.ts
+++ b/src/app/ingest/asset-ingest.operation.ts
@@ -542,7 +542,7 @@ export class AssetIngestOperation implements IngestSession {
    * @param metadata Dictionary mapping property ids to metadata values
    * @returns Result indicating whether the edit is valid or invalid.
    */
-  async updateImportedAsset(assetId: string, metadata: Dict) {
+  async updateImportedAsset(assetId: string, metadata: Dict<unknown[]>) {
     const res = await this.archive.useDb(async (db) => {
       const asset = await db.findOne(AssetImportEntity, assetId);
       if (!asset) {

--- a/src/app/ingest/asset-ingest.operation.ts
+++ b/src/app/ingest/asset-ingest.operation.ts
@@ -30,6 +30,7 @@ import {
 } from '../../common/asset.interfaces';
 import { AssetService } from '../asset/asset.service';
 import { error, FetchError, ok } from '../../common/util/error';
+import { arrayify } from '../../common/util/collection';
 
 /**
  * Encapsulates an import operation.
@@ -353,7 +354,7 @@ export class AssetIngestOperation implements IngestSession {
       value
     );
 
-    return castedValue.status === 'error' ? value : castedValue.value;
+    return arrayify(castedValue.status === 'error' ? value : castedValue.value);
   }
 
   /**
@@ -386,6 +387,8 @@ export class AssetIngestOperation implements IngestSession {
   /**
    * Return a function that transforms imported metadata keys from their the human-readable label to the metadata
    * property id.
+   *
+   * We also coerce the values into arrays, as this is the format they are stored in.
    *
    * This is a distinct step from metadata validation – since metadata values are not stored by their human-readable id,
    * we need to transform imported metadata into the schema format before we validate it.

--- a/src/app/ingest/asset-ingest.service.ts
+++ b/src/app/ingest/asset-ingest.service.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'eventemitter3';
-import { compact } from 'lodash';
+import { compact, mapValues } from 'lodash';
 
 import { IngestPhase, IngestedAsset } from '../../common/ingest.interfaces';
 import { PageRange } from '../../common/ipc.interfaces';
@@ -136,7 +136,8 @@ export class AssetIngestService extends EventEmitter<Events> {
       ...res,
       items: res.items.map((entity) => ({
         id: entity.id,
-        metadata: entity.metadata,
+        title: entity.id,
+        metadata: mapValues(entity.metadata, (rawValue) => ({ rawValue })),
         phase: entity.phase,
         validationErrors: entity.validationErrors,
         media: compact(

--- a/src/app/ingest/asset-ingest.service.ts
+++ b/src/app/ingest/asset-ingest.service.ts
@@ -137,7 +137,13 @@ export class AssetIngestService extends EventEmitter<Events> {
       items: res.items.map((entity) => ({
         id: entity.id,
         title: entity.id,
-        metadata: mapValues(entity.metadata, (rawValue) => ({ rawValue })),
+        metadata: mapValues(entity.metadata, (rawValue) => ({
+          rawValue,
+          presentationValue: rawValue.map((x) => ({
+            label: String(x),
+            rawValue: x
+          }))
+        })),
         phase: entity.phase,
         validationErrors: entity.validationErrors,
         media: compact(

--- a/src/app/migrations/Migration20220420144259.ts
+++ b/src/app/migrations/Migration20220420144259.ts
@@ -1,0 +1,20 @@
+import { Migration } from '@mikro-orm/migrations';
+import { required } from '../../common/util/assert';
+
+export class Migration20220412144332 extends Migration {
+  async up(): Promise<void> {
+    const t = required(this.ctx, 'Expected a transaction§');
+    const collections = await t.table('asset_collection').select();
+
+    for (const c of collections) {
+      const schema = JSON.parse(c.schema);
+      for (const property of schema) {
+        property.repeated = false;
+      }
+
+      await t
+        .table('asset_collection')
+        .update('schema', JSON.stringify(schema));
+    }
+  }
+}

--- a/src/common/asset.interfaces.ts
+++ b/src/common/asset.interfaces.ts
@@ -6,19 +6,33 @@ import { ResourceList } from './resource';
 import { FetchError } from './util/error';
 
 /**
+ * Represent a metadata property of an asset
+ **/
+const AssetMetadataItem = z.object({
+  rawValue: z.array(z.unknown())
+});
+export interface AssetMetadataItem<T = unknown> {
+  rawValue: T[];
+}
+
+/**
  * Represent a single asset.
  */
 export const Asset = z.object({
   /** Unique id of the asset */
   id: z.string(),
 
+  /** Title of the assset */
+  title: z.string(),
+
   /** Record of metadata associated with the asset */
-  metadata: z.record(z.unknown()),
+  metadata: z.record(AssetMetadataItem),
 
   /** All media files associated with the asset */
   media: z.array(Media)
 });
 export type Asset = z.TypeOf<typeof Asset>;
+export type AssetMetadata = Asset['metadata'];
 
 /**
  * Enum value for possible schema property types.
@@ -254,7 +268,7 @@ export const CreateAsset = RpcInterface({
   id: 'assets/create',
   request: z.object({
     collection: z.string(),
-    metadata: z.record(z.unknown())
+    metadata: z.record(z.array(z.unknown()))
   }),
   response: Asset,
   error: z.nativeEnum(FetchError)
@@ -282,7 +296,7 @@ export const UpdateAssetMetadata = RpcInterface({
   id: 'assets/update',
   request: z.object({
     assetId: z.string(),
-    payload: z.record(z.unknown())
+    payload: z.record(z.array(z.unknown()))
   }),
   response: z.object({}),
   error: z.nativeEnum(FetchError).or(SingleValidationError)

--- a/src/common/asset.interfaces.ts
+++ b/src/common/asset.interfaces.ts
@@ -9,10 +9,14 @@ import { FetchError } from './util/error';
  * Represent a metadata property of an asset
  **/
 const AssetMetadataItem = z.object({
-  rawValue: z.array(z.unknown())
+  rawValue: z.array(z.unknown().optional()),
+  presentationValue: z.array(
+    z.object({ rawValue: z.unknown().optional(), label: z.string() })
+  )
 });
 export interface AssetMetadataItem<T = unknown> {
-  rawValue: T[];
+  rawValue: (T | undefined)[];
+  presentationValue: { rawValue?: T; label: string }[];
 }
 
 /**

--- a/src/common/asset.interfaces.ts
+++ b/src/common/asset.interfaces.ts
@@ -41,6 +41,9 @@ const BaseSchemaProperty = z.object({
   /** Is the property required? */
   required: z.boolean(),
 
+  /** Does the property support multiple occurances? */
+  repeated: z.boolean(),
+
   /** Underlying type of the property? */
   type: z.nativeEnum(SchemaPropertyType)
 });
@@ -118,6 +121,7 @@ export const defaultSchemaProperty = (i: number): SchemaProperty => ({
   id: v4(),
   label: `Property ${i}`,
   required: false,
+  repeated: false,
   type: SchemaPropertyType.FREE_TEXT
 });
 

--- a/src/common/asset.interfaces.ts
+++ b/src/common/asset.interfaces.ts
@@ -5,17 +5,32 @@ import { Media } from './media.interfaces';
 import { ResourceList } from './resource';
 import { FetchError } from './util/error';
 
-/**
- * Represent a metadata property of an asset
- **/
 const AssetMetadataItem = z.object({
   rawValue: z.array(z.unknown().optional()),
   presentationValue: z.array(
     z.object({ rawValue: z.unknown().optional(), label: z.string() })
   )
 });
+/**
+ * Represent a metadata property of an asset. Contains all the information required to display or edit a single metadata
+ * property.
+ **/
 export interface AssetMetadataItem<T = unknown> {
+  /*
+   * The canonical value of the property, as stored in the database.
+   *
+   * Property values are always repredented using an array in order to allow for consistent treatment of single and
+   * repated occurances in the schema.
+   *
+   * A null value for a non-repeated property implies a rawValue of `[]`.
+   * A value for a non-repeated property implies an array of length 1
+   * A repeated property will have 0 or more elements.
+   */
   rawValue: (T | undefined)[];
+
+  /**
+   * For each element in `rawValue`, both the raw value and a human-readable string representation of it.
+   */
   presentationValue: { rawValue?: T; label: string }[];
 }
 

--- a/src/common/ingest.interfaces.ts
+++ b/src/common/ingest.interfaces.ts
@@ -127,7 +127,7 @@ export const UpdateIngestedMetadata = RpcInterface({
   request: z.object({
     assetId: z.string(),
     sessionId: z.string(),
-    metadata: z.record(z.unknown())
+    metadata: z.record(z.array(z.unknown()))
   }),
   response: z.object({})
 });

--- a/src/common/util/collection.ts
+++ b/src/common/util/collection.ts
@@ -36,3 +36,15 @@ export function compactDict<Key extends string, Val>(
     Object.entries(dict).filter((x) => x[1] !== undefined && x[1] !== null)
   ) as Dict<Val, Key>;
 }
+
+export function arrayify<T>(val: T | null | undefined | T[]): T[] {
+  if (val === undefined || val === null) {
+    return [];
+  }
+
+  if (Array.isArray(val)) {
+    return val;
+  }
+
+  return [val];
+}

--- a/src/frontend/screens/collection.screen.tsx
+++ b/src/frontend/screens/collection.screen.tsx
@@ -71,6 +71,7 @@ export const CollectionScreen: FC = () => {
   const newAsset = useCallback(() => {
     setPendingAsset({
       id: '$pending',
+      title: '[New Item]',
       media: [],
       metadata: {}
     });

--- a/src/frontend/screens/collection.screen.tsx
+++ b/src/frontend/screens/collection.screen.tsx
@@ -5,10 +5,9 @@ import {
   Asset,
   GetCollection,
   ListAssets,
-  SchemaProperty,
-  SchemaPropertyType
+  SchemaProperty
 } from '../../common/asset.interfaces';
-import { never, required } from '../../common/util/assert';
+import { required } from '../../common/util/assert';
 import {
   iterateListCursor,
   ListCursor,
@@ -16,7 +15,6 @@ import {
   useGet,
   useList
 } from '../ipc/ipc.hooks';
-import { ReferenceCell, TextCell } from '../ui/components/grid-cell.component';
 import { DataGrid, GridColumn } from '../ui/components/grid.component';
 import { AssetDetail } from '../ui/components/asset-detail.component';
 import {
@@ -28,6 +26,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useContextMenu } from '../ui/hooks/menu.hooks';
 import { IconButton } from 'theme-ui';
 import { Gear, Plus } from 'react-bootstrap-icons';
+import { MetadataItemCell } from '../ui/components/grid-cell.component';
 
 /**
  * Screen for viewing the assets in a collection.
@@ -166,22 +165,10 @@ export const CollectionScreen: FC = () => {
  */
 const getGridColumns = (schema: SchemaProperty[]) =>
   schema.map((property): GridColumn<Asset> => {
-    if (property.type === SchemaPropertyType.FREE_TEXT) {
-      return {
-        id: property.id,
-        cell: TextCell,
-        getData: (x) => x.metadata[property.id],
-        label: property.label
-      };
-    }
-    if (property.type === SchemaPropertyType.CONTROLLED_DATABASE) {
-      return {
-        id: property.id,
-        cell: ReferenceCell,
-        getData: (x) => x.metadata[property.id],
-        label: property.label
-      };
-    }
-
-    return never(property);
+    return {
+      id: property.id,
+      cell: MetadataItemCell,
+      getData: (x) => x.metadata[property.id],
+      label: property.label
+    };
   });

--- a/src/frontend/screens/ingest.screen.tsx
+++ b/src/frontend/screens/ingest.screen.tsx
@@ -4,9 +4,10 @@ import { FC, useCallback, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from 'theme-ui';
 import {
+  Asset,
+  AssetMetadataItem,
   GetRootAssetsCollection,
-  SchemaProperty,
-  SchemaPropertyType
+  SchemaProperty
 } from '../../common/asset.interfaces';
 import {
   IngestPhase,
@@ -16,13 +17,12 @@ import {
   GetIngestSession,
   CancelIngestSession
 } from '../../common/ingest.interfaces';
-import { never, required } from '../../common/util/assert';
+import { required } from '../../common/util/assert';
 import { iterateListCursor, useGet, useList, useRPC } from '../ipc/ipc.hooks';
 import { ProgressValue } from '../ui/components/atoms.component';
 import {
-  ProgressCell,
-  ReferenceCell,
-  TextCell
+  MetadataItemCell,
+  ProgressCell
 } from '../ui/components/grid-cell.component';
 import { DataGrid, GridColumn } from '../ui/components/grid.component';
 import { AssetDetail } from '../ui/components/asset-detail.component';
@@ -164,25 +164,13 @@ function useCancelImport(sessionId: string) {
  * @returns An array of DataGrid columns for each property in the schma.
  */
 const getGridColumns = (schema: SchemaProperty[]) => {
-  const metadataColumns = schema.map((property): GridColumn<IngestedAsset> => {
-    if (property.type === SchemaPropertyType.FREE_TEXT) {
-      return {
-        id: property.id,
-        cell: TextCell,
-        getData: (x) => x.metadata[property.id],
-        label: property.label
-      };
-    }
-    if (property.type === SchemaPropertyType.CONTROLLED_DATABASE) {
-      return {
-        id: property.id,
-        cell: ReferenceCell,
-        getData: (x) => x.metadata[property.id],
-        label: property.label
-      };
-    }
-
-    return never(property);
+  const metadataColumns = schema.map((property): GridColumn<Asset> => {
+    return {
+      id: property.id,
+      cell: MetadataItemCell,
+      getData: (x) => x.metadata[property.id],
+      label: property.label
+    };
   });
 
   return [

--- a/src/frontend/screens/schema.screen.tsx
+++ b/src/frontend/screens/schema.screen.tsx
@@ -72,15 +72,34 @@ export const SchemaScreen = () => {
 
   return (
     <>
-      <SchemaEditor
-        sx={{ flex: 1, overflowY: 'auto', width: '100%' }}
-        value={state}
-        errors={errors}
-        onChange={(change) => {
-          setHasEdits(true);
-          setState(change);
-        }}
-      />
+      {/*
+        This intermediary div is required due to an absolutely baffling css bug.
+
+        If we set `overflow-y: auto` on the child element, any update to the DOM while the child is scrolled on the Y
+        axis causes the _parent_ of this component to be repositioned to a Y value inversely proportional to the scroll
+        offset.
+
+        In practice, this means that if a switch is toggled while the editor is scrolled, the contents of the editor
+        disappear.
+
+        For reasons that I don't fully understand, this doesn't happen when the scroll contents are wrapped in a div.
+
+        This is likely a bug a flexbox/overflow bug in chromium (as of v100), so it may be possible to remove the
+        intermediary div if/when it is fixed.
+      */}
+      <div
+        sx={{ overflowY: 'auto', flex: 1, width: '100%', position: 'relative' }}
+      >
+        <SchemaEditor
+          sx={{ width: '100%' }}
+          value={state}
+          errors={errors}
+          onChange={(change) => {
+            setHasEdits(true);
+            setState(change);
+          }}
+        />
+      </div>
       <BottomBar
         actions={
           <>

--- a/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
+++ b/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
@@ -4,12 +4,11 @@ import faker from '@faker-js/faker';
 import { FC, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 import {
-  assetMetadataFromRawValues,
+  assetMetadata,
   someAsset,
   someMetadata
 } from '../../../../app/asset/test-utils';
 import {
-  AssetMetadata,
   CollectionType,
   GetCollection,
   SchemaProperty,
@@ -21,7 +20,6 @@ import { Media } from '../../../../common/media.interfaces';
 import { never } from '../../../../common/util/assert';
 import { compactDict } from '../../../../common/util/collection';
 import { error, ok } from '../../../../common/util/error';
-import { Dict } from '../../../../common/util/types';
 import { IpcContext } from '../../../ipc/ipc.hooks';
 import { MockIpc } from '../../../ipc/mock-ipc';
 import { AssetDetail } from '../asset-detail.component';
@@ -42,7 +40,7 @@ export const NarrowWithMedia: FC<Params> = ({ onUpdate }) => {
   });
 
   const ipc = useIpcFixture((change) => {
-    setMetadata(assetMetadataFromRawValues(change.payload));
+    setMetadata(assetMetadata(change.payload));
     onUpdate(change);
   });
 
@@ -75,7 +73,7 @@ export const CreateMode: FC<Params> = ({ onUpdate }) => {
   });
 
   const ipc = useIpcFixture((change) => {
-    setMetadata(assetMetadataFromRawValues(change.payload));
+    setMetadata(assetMetadata(change.payload));
     onUpdate(change);
   });
 
@@ -187,7 +185,9 @@ const Validator = z.object(
 
       return [
         property.id,
-        property.required ? validator : validator.optional()
+        property.required
+          ? z.array(validator).min(1)
+          : z.array(validator).optional()
       ];
     })
   )

--- a/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
+++ b/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
@@ -162,12 +162,14 @@ const SCHEMA: SchemaProperty[] = [
     id: 'someProperty',
     label: 'Some Property',
     required: true,
+    repeated: false,
     type: SchemaPropertyType.FREE_TEXT
   },
   {
     id: 'databaseRef',
     label: 'Database Reference',
     required: false,
+    repeated: false,
     type: SchemaPropertyType.CONTROLLED_DATABASE,
     databaseId: 'testDb'
   }

--- a/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
+++ b/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
@@ -4,6 +4,12 @@ import faker from '@faker-js/faker';
 import { FC, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 import {
+  assetMetadataFromRawValues,
+  someAsset,
+  someMetadata
+} from '../../../../app/asset/test-utils';
+import {
+  AssetMetadata,
   CollectionType,
   GetCollection,
   SchemaProperty,
@@ -30,15 +36,13 @@ interface Params {
 }
 
 export const NarrowWithMedia: FC<Params> = ({ onUpdate }) => {
-  const [metadata, setMetadata] = useState<Dict>(() => {
+  const [metadata, setMetadata] = useState(() => {
     faker.seed(1);
-    return {
-      someProperty: faker.lorem.words(3)
-    };
+    return someMetadata(SCHEMA);
   });
 
   const ipc = useIpcFixture((change) => {
-    setMetadata(change.payload);
+    setMetadata(assetMetadataFromRawValues(change.payload));
     onUpdate(change);
   });
 
@@ -51,11 +55,7 @@ export const NarrowWithMedia: FC<Params> = ({ onUpdate }) => {
           height: '100vh',
           overflow: 'auto'
         }}
-        asset={{
-          id: faker.datatype.uuid(),
-          media: MEDIA_FILES,
-          metadata: metadata
-        }}
+        asset={someAsset({ metadata })}
         collection={{
           id: 'someCollection',
           title: 'Some Collection',
@@ -69,15 +69,13 @@ export const NarrowWithMedia: FC<Params> = ({ onUpdate }) => {
 };
 
 export const CreateMode: FC<Params> = ({ onUpdate }) => {
-  const [metadata, setMetadata] = useState<Dict>(() => {
+  const [metadata, setMetadata] = useState(() => {
     faker.seed(1);
-    return {
-      someProperty: faker.lorem.words(3)
-    };
+    return someMetadata(SCHEMA);
   });
 
   const ipc = useIpcFixture((change) => {
-    setMetadata(change.payload);
+    setMetadata(assetMetadataFromRawValues(change.payload));
     onUpdate(change);
   });
 
@@ -90,11 +88,10 @@ export const CreateMode: FC<Params> = ({ onUpdate }) => {
           height: '100vh',
           overflow: 'auto'
         }}
-        asset={{
-          id: faker.datatype.uuid(),
+        asset={someAsset({
           media: MEDIA_FILES,
-          metadata: metadata
-        }}
+          metadata
+        })}
         collection={{
           id: 'someCollection',
           title: 'Some Collection',

--- a/src/frontend/ui/components/__stories__/grid.stories.tsx
+++ b/src/frontend/ui/components/__stories__/grid.stories.tsx
@@ -5,6 +5,7 @@ import { EventEmitter } from 'eventemitter3';
 import { noop, times } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
+import { AssetMetadataItem } from '../../../../common/asset.interfaces';
 
 import { RpcInterface } from '../../../../common/ipc.interfaces';
 import {
@@ -16,7 +17,7 @@ import { IpcContext, ListCursor, useList } from '../../../ipc/ipc.hooks';
 import { MockIpc } from '../../../ipc/mock-ipc';
 import { SelectionContext } from '../../hooks/selection.hooks';
 import { Window } from '../../window';
-import { TextCell } from '../grid-cell.component';
+import { MetadataItemCell, StringCell } from '../grid-cell.component';
 import { DataGrid, GridColumn } from '../grid.component';
 
 export default {
@@ -63,13 +64,13 @@ export const ExampleDataGrid = () => {
         id: 'name',
         label: 'Name',
         getData: (x: GridDatum) => x.name,
-        cell: TextCell
+        cell: StringCell
       },
       {
         id: 'favouriteDog',
         label: 'Dog',
         getData: (x: GridDatum) => x.favouriteDog,
-        cell: TextCell
+        cell: StringCell
       }
     ],
     []
@@ -147,19 +148,19 @@ export const InFlightUpdates = () => {
   const StoryImpl = useCallback(function StoryImpl() {
     const data = useList(TestUpdate, () => ({}), []);
 
-    const columns: GridColumn<GridDatum>[] = useMemo(
+    const columns: GridColumn<GridDatum, string>[] = useMemo(
       () => [
         {
           id: 'name',
           label: 'Name',
           getData: (x: GridDatum) => x.name,
-          cell: TextCell
+          cell: StringCell
         },
         {
           id: 'favouriteDog',
           label: 'Dog',
           getData: (x: GridDatum) => x.favouriteDog,
-          cell: TextCell
+          cell: StringCell
         }
       ],
       []

--- a/src/frontend/ui/components/__stories__/schema-editor.stories.tsx
+++ b/src/frontend/ui/components/__stories__/schema-editor.stories.tsx
@@ -34,6 +34,7 @@ export const WithProperties = () => {
       id: String(i),
       label: faker.animal.dog(),
       required: faker.datatype.boolean(),
+      repeated: false,
       type: SchemaPropertyType.FREE_TEXT
     }))
   );
@@ -54,6 +55,7 @@ export const WithErrors = () => {
       id: String(i),
       label: faker.animal.dog(),
       required: faker.datatype.boolean(),
+      repeated: false,
       type: SchemaPropertyType.FREE_TEXT
     }))
   );

--- a/src/frontend/ui/components/__tests__/asset-detail.spec.tsx
+++ b/src/frontend/ui/components/__tests__/asset-detail.spec.tsx
@@ -9,6 +9,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PropsWithChildren } from 'react';
+import { someAsset, someMetadata } from '../../../../app/asset/test-utils';
 import {
   Asset,
   CollectionType,
@@ -42,7 +43,9 @@ const SCHEMA: SchemaProperty[] = [
 describe(AssetDetail, () => {
   test('Editing an asset and saving changes submits a change request, then resets the editing state', async () => {
     const fixture = setup();
-    const asset = someAsset();
+    const asset = someAsset({
+      metadata: someMetadata(SCHEMA)
+    });
     const onUpdate = fixture.givenThatTheUpdateSucceeds();
 
     const tree = render(
@@ -68,7 +71,9 @@ describe(AssetDetail, () => {
 
   test('Editing an asset and canceling changes does not submit a change request and resets the editing state', async () => {
     const fixture = setup();
-    const asset = someAsset();
+    const asset = someAsset({
+      metadata: someMetadata(SCHEMA)
+    });
 
     const onUpdate = fixture.givenThatTheUpdateSucceeds();
 
@@ -91,7 +96,9 @@ describe(AssetDetail, () => {
 
   test('Validation errors are displayed to the user', async () => {
     const fixture = setup();
-    const asset = someAsset();
+    const asset = someAsset({
+      metadata: someMetadata(SCHEMA)
+    });
 
     fixture.givenThatTheUpdateFails({
       someProperty: ['Oops']
@@ -194,11 +201,3 @@ async function shouldDisplayReadonlyProperyValue(
 
   expect(propertyValue.innerHTML).toEqual(metadata[property.id]);
 }
-
-const someAsset = (): Asset => ({
-  id: 'myAsset',
-  media: [],
-  metadata: {
-    someProperty: 'Hi'
-  }
-});

--- a/src/frontend/ui/components/__tests__/asset-detail.spec.tsx
+++ b/src/frontend/ui/components/__tests__/asset-detail.spec.tsx
@@ -27,12 +27,14 @@ const SCHEMA: SchemaProperty[] = [
     id: 'someProperty',
     label: 'Some Property',
     required: true,
+    repeated: false,
     type: SchemaPropertyType.FREE_TEXT
   },
   {
     id: 'someOtherProperty',
     label: 'Some Other Property',
     required: false,
+    repeated: false,
     type: SchemaPropertyType.FREE_TEXT
   }
 ];

--- a/src/frontend/ui/components/__tests__/asset-detail.spec.tsx
+++ b/src/frontend/ui/components/__tests__/asset-detail.spec.tsx
@@ -11,7 +11,8 @@ import userEvent from '@testing-library/user-event';
 import { PropsWithChildren } from 'react';
 import { someAsset, someMetadata } from '../../../../app/asset/test-utils';
 import {
-  Asset,
+  AssetMetadata,
+  AssetMetadataItem,
   CollectionType,
   SchemaProperty,
   SchemaPropertyType,
@@ -22,6 +23,7 @@ import { Dict } from '../../../../common/util/types';
 import { IpcContext } from '../../../ipc/ipc.hooks';
 import { MockIpc } from '../../../ipc/mock-ipc';
 import { AssetDetail } from '../asset-detail.component';
+import { fieldDisplayTestId } from '../schema-form.component';
 
 const SCHEMA: SchemaProperty[] = [
   {
@@ -64,7 +66,7 @@ describe(AssetDetail, () => {
 
     expect(onUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        payload: expect.objectContaining({ someProperty: 'New Value' })
+        payload: expect.objectContaining({ someProperty: ['New Value'] })
       })
     );
   });
@@ -85,7 +87,7 @@ describe(AssetDetail, () => {
 
     await beginEditing(tree);
     await editMetadataFields(tree, {
-      'Some Property': 'New Value'
+      'Some Property': ['New Value']
     });
     await requestCancel(tree);
     await waitForEditModeToEnd(tree);
@@ -194,10 +196,11 @@ async function waitForEditModeToEnd(tree: RenderResult) {
 async function shouldDisplayReadonlyProperyValue(
   tree: RenderResult,
   property: SchemaProperty,
-  metadata: Dict
+  metadata: AssetMetadata
 ) {
-  const propertyValue = tree.getByText(property.label)
-    .nextSibling as HTMLElement;
+  metadata[property.id].presentationValue.forEach((md, i) => {
+    const propertyValue = tree.getByTestId(fieldDisplayTestId(property, i));
 
-  expect(propertyValue.innerHTML).toEqual(metadata[property.id]);
+    expect(propertyValue.innerHTML).toEqual(md.label);
+  });
 }

--- a/src/frontend/ui/components/asset-detail.component.tsx
+++ b/src/frontend/ui/components/asset-detail.component.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource theme-ui */
 
+import { mapValues } from 'lodash';
 import { FC, useCallback, useMemo, useState } from 'react';
 import { CardList, Collection as CollectionIcon } from 'react-bootstrap-icons';
 import {
@@ -14,6 +15,7 @@ import {
 } from 'theme-ui';
 import {
   Asset,
+  AssetMetadata,
   Collection,
   CollectionType,
   CreateAsset,
@@ -70,7 +72,7 @@ export const AssetDetail: FC<MediaDetailProps> = ({
   const [tabId, setTabId] = useState(
     initialTab || (showMedia && 'Media') || undefined
   );
-  const [edits, setEdits] = useState<Dict | undefined>(
+  const [edits, setEdits] = useState<AssetMetadata | undefined>(
     action === 'create' ? {} : undefined
   );
   const rpc = useRPC();
@@ -93,7 +95,7 @@ export const AssetDetail: FC<MediaDetailProps> = ({
   const updateAsset = useCallback(async () => {
     const res = await rpc(UpdateAssetMetadata, {
       assetId: asset.id,
-      payload: metadata
+      payload: mapValues(metadata, (item) => item.rawValue)
     });
     if (res.status === 'error') {
       if (res.error === FetchError.DOES_NOT_EXIST) {
@@ -112,7 +114,7 @@ export const AssetDetail: FC<MediaDetailProps> = ({
   const createAsset = useCallback(async () => {
     const res = await rpc(CreateAsset, {
       collection: collection.id,
-      metadata
+      metadata: mapValues(metadata, (item) => item.rawValue)
     });
 
     if (res.status === 'error') {

--- a/src/frontend/ui/components/asset-detail.component.tsx
+++ b/src/frontend/ui/components/asset-detail.component.tsx
@@ -139,7 +139,7 @@ export const AssetDetail: FC<MediaDetailProps> = ({
 
     const res = await rpc(UpdateIngestedMetadata, {
       assetId: asset.id,
-      metadata,
+      metadata: mapValues(metadata, (md) => md.rawValue),
       sessionId
     });
 

--- a/src/frontend/ui/components/atoms.component.tsx
+++ b/src/frontend/ui/components/atoms.component.tsx
@@ -263,7 +263,7 @@ export function RelationSelect<
   Group extends GroupBase<Option> = GroupBase<Option>
 >(props: AsyncProps<Option, IsMulti, Group>) {
   const { theme } = useThemeUI();
-  console.log(theme.forms);
+
   return (
     <AsyncSelect
       styles={{

--- a/src/frontend/ui/components/grid-cell.component.tsx
+++ b/src/frontend/ui/components/grid-cell.component.tsx
@@ -38,9 +38,6 @@ const presentationValue = (val?: AssetMetadataItem) => {
   return val.presentationValue.map((x) => x.label).join('; ');
 };
 
-const guessTextWidth = (text: string | undefined, fontSize: number) => {
-  return Math.max(
-    100,
-    Math.min(600, text ? text.length * fontSize * 0.4 : 300)
-  );
+export const guessTextWidth = (text: string | undefined, fontSize: number) => {
+  return Math.max(36, Math.min(600, text ? text.length * fontSize * 0.8 : 500));
 };

--- a/src/frontend/ui/components/grid-cell.component.tsx
+++ b/src/frontend/ui/components/grid-cell.component.tsx
@@ -1,17 +1,19 @@
 /** @jsxImportSource theme-ui */
 
-import { GetAsset } from '../../../common/asset.interfaces';
-import { SKIP_FETCH, unwrapGetResult, useGet } from '../../ipc/ipc.hooks';
+import { AssetMetadataItem } from '../../../common/asset.interfaces';
 import { ProgressIndicator, ProgressValue } from './atoms.component';
 import { DataGridCell } from './grid.component';
 
 /** Datagrid cell for free text */
 export const TextCell: DataGridCell<string> = ({ value }) => (
-  <>{value?.rawValue.join('; ')}</>
+  <>{presentationValue(value)}</>
 );
 
 TextCell.width = (data, fontSize) =>
-  Math.max(100, Math.min(600, data ? data.length * fontSize * 0.4 : 300));
+  Math.max(
+    100,
+    Math.min(600, data ? presentationValue(data).length * fontSize * 0.4 : 300)
+  );
 
 /** Datagrid cell for indicating progress */
 export const ProgressCell: DataGridCell<ProgressValue> = ({ value }) => {
@@ -30,15 +32,19 @@ ProgressCell.width = 36;
 
 /** Datagrid cell for database references */
 export const ReferenceCell: DataGridCell<string> = ({ value }) => {
-  const idReference = value?.rawValue[0];
-  const asset = unwrapGetResult(useGet(GetAsset, idReference ?? SKIP_FETCH));
-
-  if (!asset) {
-    return null;
-  }
-
-  return <>{asset.title}</>;
+  return <>{presentationValue(value)}</>;
 };
 
 ReferenceCell.width = (data, fontSize) =>
-  Math.max(100, Math.min(600, data ? data.length * fontSize * 0.4 : 300));
+  Math.max(
+    100,
+    Math.min(600, data ? presentationValue(data).length * fontSize * 0.4 : 300)
+  );
+
+const presentationValue = (val?: AssetMetadataItem<unknown>) => {
+  if (!val || val.presentationValue.length === 0) {
+    return '-';
+  }
+
+  return val.presentationValue.map((x) => x.label).join('; ');
+};

--- a/src/frontend/ui/components/grid-cell.component.tsx
+++ b/src/frontend/ui/components/grid-cell.component.tsx
@@ -4,47 +4,43 @@ import { AssetMetadataItem } from '../../../common/asset.interfaces';
 import { ProgressIndicator, ProgressValue } from './atoms.component';
 import { DataGridCell } from './grid.component';
 
-/** Datagrid cell for free text */
-export const TextCell: DataGridCell<string> = ({ value }) => (
-  <>{presentationValue(value)}</>
-);
+/** Datagrid cell for raw strings */
+export const StringCell: DataGridCell<string> = ({ value }) => <>{value}</>;
 
-TextCell.width = (data, fontSize) =>
-  Math.max(
-    100,
-    Math.min(600, data ? presentationValue(data).length * fontSize * 0.4 : 300)
-  );
+StringCell.width = (value, fontSize) => guessTextWidth(value, fontSize);
+
+/** For any schema property, render its semicolon-delimited presentation value */
+export const MetadataItemCell: DataGridCell<AssetMetadataItem> = ({
+  value
+}) => <>{presentationValue(value)}</>;
+
+MetadataItemCell.width = (data, fontSize) =>
+  guessTextWidth(presentationValue(data), fontSize);
 
 /** Datagrid cell for indicating progress */
 export const ProgressCell: DataGridCell<ProgressValue> = ({ value }) => {
-  const percentVal = value?.rawValue[0];
-
   return (
     <div
       sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
     >
-      <ProgressIndicator value={percentVal} />
+      <ProgressIndicator value={value} />
     </div>
   );
 };
 
 ProgressCell.width = 36;
 
-/** Datagrid cell for database references */
-export const ReferenceCell: DataGridCell<string> = ({ value }) => {
-  return <>{presentationValue(value)}</>;
-};
-
-ReferenceCell.width = (data, fontSize) =>
-  Math.max(
-    100,
-    Math.min(600, data ? presentationValue(data).length * fontSize * 0.4 : 300)
-  );
-
-const presentationValue = (val?: AssetMetadataItem<unknown>) => {
+const presentationValue = (val?: AssetMetadataItem) => {
   if (!val || val.presentationValue.length === 0) {
     return '-';
   }
 
   return val.presentationValue.map((x) => x.label).join('; ');
+};
+
+const guessTextWidth = (text: string | undefined, fontSize: number) => {
+  return Math.max(
+    100,
+    Math.min(600, text ? text.length * fontSize * 0.4 : 300)
+  );
 };

--- a/src/frontend/ui/components/grid-cell.component.tsx
+++ b/src/frontend/ui/components/grid-cell.component.tsx
@@ -1,51 +1,43 @@
 /** @jsxImportSource theme-ui */
 
-import {
-  GetAsset,
-  GetCollection,
-  GetRootAssetsCollection,
-  GetRootDatabaseCollection,
-  SchemaPropertyType
-} from '../../../common/asset.interfaces';
-import { assert } from '../../../common/util/assert';
+import { GetAsset } from '../../../common/asset.interfaces';
 import { SKIP_FETCH, unwrapGetResult, useGet } from '../../ipc/ipc.hooks';
 import { ProgressIndicator, ProgressValue } from './atoms.component';
 import { DataGridCell } from './grid.component';
 
 /** Datagrid cell for free text */
-export const TextCell: DataGridCell<string> = ({ value }) => <>{value}</>;
+export const TextCell: DataGridCell<string> = ({ value }) => (
+  <>{value?.rawValue.join('; ')}</>
+);
 
 TextCell.width = (data, fontSize) =>
   Math.max(100, Math.min(600, data ? data.length * fontSize * 0.4 : 300));
 
 /** Datagrid cell for indicating progress */
-export const ProgressCell: DataGridCell<ProgressValue> = ({ value }) => (
-  <div sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-    <ProgressIndicator value={value} />
-  </div>
-);
+export const ProgressCell: DataGridCell<ProgressValue> = ({ value }) => {
+  const percentVal = value?.rawValue[0];
+
+  return (
+    <div
+      sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+    >
+      <ProgressIndicator value={percentVal} />
+    </div>
+  );
+};
 
 ProgressCell.width = 36;
 
 /** Datagrid cell for database references */
-export const ReferenceCell: DataGridCell<string> = ({ value, property }) => {
-  const asset = unwrapGetResult(useGet(GetAsset, value ?? SKIP_FETCH));
-  const collection = unwrapGetResult(useGet(GetRootAssetsCollection));
-  const propertyValue = collection?.schema.find((x) => x.id === property);
+export const ReferenceCell: DataGridCell<string> = ({ value }) => {
+  const idReference = value?.rawValue[0];
+  const asset = unwrapGetResult(useGet(GetAsset, idReference ?? SKIP_FETCH));
 
-  const dbId =
-    propertyValue?.type == SchemaPropertyType.CONTROLLED_DATABASE
-      ? propertyValue.databaseId
-      : undefined;
-  const dbSchema = unwrapGetResult(useGet(GetCollection, dbId ?? SKIP_FETCH));
-
-  if (!dbSchema || !asset) {
+  if (!asset) {
     return null;
   }
 
-  const titleProp = dbSchema.schema[0]?.id;
-
-  return <>{asset.metadata[titleProp]}</>;
+  return <>{asset.title}</>;
 };
 
 ReferenceCell.width = (data, fontSize) =>

--- a/src/frontend/ui/components/grid.component.tsx
+++ b/src/frontend/ui/components/grid.component.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /** @jsxImportSource theme-ui */
 
 import {
@@ -26,14 +27,13 @@ import { compact, last, max, noop, sum } from 'lodash';
 import { useEventEmitter } from '../hooks/state.hooks';
 import { SelectionContext } from '../hooks/selection.hooks';
 import { PageRange } from '../../../common/ipc.interfaces';
-import { AssetMetadataItem } from '../../../common/asset.interfaces';
 
 export interface DataGridProps<T extends Resource> extends BoxProps {
   /** Data to present */
   data: ListCursor<T>;
 
   /** Specification of the grid columns */
-  columns: GridColumn<T>[];
+  columns: GridColumn<T, any>[];
 
   /** Font size used to size grid rows and set their inner font size */
   fontSize?: number;
@@ -243,7 +243,7 @@ export function DataGrid<T extends Resource>({
  * Specify data access and presentation for a grid row.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface GridColumn<T extends Resource = Resource, Val = any> {
+export interface GridColumn<T = unknown, Val = any> {
   /** Unique id of the column */
   id: string;
 
@@ -259,7 +259,7 @@ export interface GridColumn<T extends Resource = Resource, Val = any> {
 
 /** Presentation component for a datagrid */
 export type DataGridCell<Val = unknown> = FC<{
-  value?: AssetMetadataItem<Val>;
+  value?: Val;
   property: string;
 }> & {
   /**
@@ -267,9 +267,7 @@ export type DataGridCell<Val = unknown> = FC<{
    *
    * Provieding a function will cause the size to be estimated based on a sample of the grid data.
    **/
-  width?:
-    | number
-    | ((val: AssetMetadataItem<Val> | undefined, fontSize: number) => number);
+  width?: number | ((val: Val | undefined, fontSize: number) => number);
 };
 
 /**

--- a/src/frontend/ui/components/grid.component.tsx
+++ b/src/frontend/ui/components/grid.component.tsx
@@ -27,6 +27,7 @@ import { compact, last, max, noop, sum } from 'lodash';
 import { useEventEmitter } from '../hooks/state.hooks';
 import { SelectionContext } from '../hooks/selection.hooks';
 import { PageRange } from '../../../common/ipc.interfaces';
+import { guessTextWidth } from './grid-cell.component';
 
 export interface DataGridProps<T extends Resource> extends BoxProps {
   /** Data to present */
@@ -85,7 +86,10 @@ export function DataGrid<T extends Resource>({
 
         if (typeof width === 'function') {
           return (
-            max(dataSample.map((x) => width(col.getData(x), fontSize))) ?? 100
+            max([
+              guessTextWidth(col.label, fontSize),
+              ...dataSample.map((x) => width(col.getData(x), fontSize))
+            ]) ?? 100
           );
         }
 

--- a/src/frontend/ui/components/grid.component.tsx
+++ b/src/frontend/ui/components/grid.component.tsx
@@ -13,7 +13,9 @@ import {
   useRef,
   useState
 } from 'react';
-import AutoSizer, { Size } from 'react-virtualized-auto-sizer';
+import { take } from 'streaming-iterables';
+import produce from 'immer';
+import AutoSizer from 'react-virtualized-auto-sizer';
 import Loader from 'react-window-infinite-loader';
 import { ListChildComponentProps, FixedSizeList } from 'react-window';
 import { Box, BoxProps, ThemeUIStyleObject, useThemeUI } from 'theme-ui';
@@ -24,8 +26,7 @@ import { compact, last, max, noop, sum } from 'lodash';
 import { useEventEmitter } from '../hooks/state.hooks';
 import { SelectionContext } from '../hooks/selection.hooks';
 import { PageRange } from '../../../common/ipc.interfaces';
-import { take } from 'streaming-iterables';
-import produce from 'immer';
+import { AssetMetadataItem } from '../../../common/asset.interfaces';
 
 export interface DataGridProps<T extends Resource> extends BoxProps {
   /** Data to present */
@@ -258,7 +259,7 @@ export interface GridColumn<T extends Resource = Resource, Val = any> {
 
 /** Presentation component for a datagrid */
 export type DataGridCell<Val = unknown> = FC<{
-  value: Val;
+  value?: AssetMetadataItem<Val>;
   property: string;
 }> & {
   /**

--- a/src/frontend/ui/components/grid.component.tsx
+++ b/src/frontend/ui/components/grid.component.tsx
@@ -267,7 +267,9 @@ export type DataGridCell<Val = unknown> = FC<{
    *
    * Provieding a function will cause the size to be estimated based on a sample of the grid data.
    **/
-  width?: number | ((val: Val | undefined, fontSize: number) => number);
+  width?:
+    | number
+    | ((val: AssetMetadataItem<Val> | undefined, fontSize: number) => number);
 };
 
 /**

--- a/src/frontend/ui/components/page-layouts.component.tsx
+++ b/src/frontend/ui/components/page-layouts.component.tsx
@@ -332,8 +332,7 @@ export const PrimaryDetailLayout: FC<
         },
         '> .reflex-element': {
           overflow: 'hidden'
-        },
-        minHeight: 0
+        }
       }}
       windowResizeAware
       orientation="vertical"

--- a/src/frontend/ui/components/page-layouts.component.tsx
+++ b/src/frontend/ui/components/page-layouts.component.tsx
@@ -332,7 +332,8 @@ export const PrimaryDetailLayout: FC<
         },
         '> .reflex-element': {
           overflow: 'hidden'
-        }
+        },
+        minHeight: 0
       }}
       windowResizeAware
       orientation="vertical"

--- a/src/frontend/ui/components/schema-editor.component.tsx
+++ b/src/frontend/ui/components/schema-editor.component.tsx
@@ -230,23 +230,50 @@ export const SchemaEditor: FC<SchemaEditorProps> = ({
             {getExtraConfigProperties(item)}
           </Grid>
 
-          <Box sx={{ width: '100%', pt: 4 }}>
-            <Switch
-              sx={{
-                'input:checked ~ &': {
-                  backgroundColor: 'var(--theme-ui-colors-primary)'
-                }
-              }}
-              label="Required"
-              checked={item.required}
-              onChange={changeCallback(
-                item.id,
-                (prev, event: ChangeEvent<HTMLInputElement>) => {
-                  prev.required = event.currentTarget.checked;
-                }
-              )}
-            />
-          </Box>
+          <Flex
+            sx={{
+              width: '100%',
+              flexDirection: 'row',
+              pt: 5,
+              justifyContent: 'flex-start',
+              '> *': { mr: 6 }
+            }}
+          >
+            <Box>
+              <Switch
+                sx={{
+                  'input:checked ~ &': {
+                    backgroundColor: 'var(--theme-ui-colors-primary)'
+                  }
+                }}
+                label="Required"
+                checked={item.required}
+                onChange={changeCallback(
+                  item.id,
+                  (prev, event: ChangeEvent<HTMLInputElement>) => {
+                    prev.required = event.currentTarget.checked;
+                  }
+                )}
+              />
+            </Box>
+            <Box>
+              <Switch
+                sx={{
+                  'input:checked ~ &': {
+                    backgroundColor: 'var(--theme-ui-colors-primary)'
+                  }
+                }}
+                label="Repeated"
+                checked={item.repeated}
+                onChange={changeCallback(
+                  item.id,
+                  (prev, event: ChangeEvent<HTMLInputElement>) => {
+                    prev.repeated = event.currentTarget.checked;
+                  }
+                )}
+              />
+            </Box>
+          </Flex>
 
           <Box>
             {errors[item.id]?.length > 0 && (

--- a/src/frontend/ui/components/schema-form.component.tsx
+++ b/src/frontend/ui/components/schema-form.component.tsx
@@ -188,7 +188,7 @@ export const DatabaseReferenceField: FC<SchemaFormFieldProps<string>> = ({
         <Label>{property.label}</Label>
         <RelationSelect
           loadOptions={promiseOptions}
-          value={value?.presentationValue[0]}
+          value={value?.presentationValue?.[0]}
           data-testid={fieldEditTestId(property)}
           getOptionLabel={(opt) => opt?.label ?? ''}
           getOptionValue={(opt) => opt?.rawValue ?? ''}
@@ -317,10 +317,10 @@ const ReadonlyDisplay: FC<{
   );
 };
 
-export function fieldDisplayTestId(property: SchemaProperty, i: number = 0) {
+export function fieldDisplayTestId(property: SchemaProperty, i = 0) {
   return `metadata-display-${property.id}@${i}`;
 }
 
-export function fieldEditTestId(property: SchemaProperty, i: number = 0) {
+export function fieldEditTestId(property: SchemaProperty, i = 0) {
   return `metadata-edit-${property.id}@${i}`;
 }


### PR DESCRIPTION
This adds support for repeated properties in the schema. All properties (of any type) can now be marked as either repeated or non-repeated, with repeated properties having appropriate UI elements for assigning and removing values.

![screen](https://user-images.githubusercontent.com/361391/168643771-97c56bca-c3c8-4eb6-bed4-ff0510091f60.gif)

(some visual design required)

In the process of doing this, we slightly change the way metadata is stored in the database and shared with the frontend.

** Breaking **

The archive file format used by this version is backwards-incompatible with previous releases.

**Storage**

In order to accomodate properties with multiple occurance consistently, we now store all metadata in the database as arrays. So, if an asset's metadata was previously stored as:

```json
{
   "property1": "foo"
}
``` 

then it will now be stored as:

```json
{
   "property1": ["foo"]
}
```

Doing this means that, for example, when a property is moved from being non-repeated to repeated, no transformation of the stored data is required. It also means that, outside of UI presentation and validation, we don't have to handle repeated properties any differently to non-repeated ones, which avoids some additional code complexity.

A downside of this is that repeated properties are now embedded in an array inside a json field, which makes filtering them harder. It may make sense in future to split metadata properties out into their own database column rather than using json objects as we currently do.

A database migration will convert all metadata to the new format.

** Introducing `AssetMetadata` and `AssetMetadataItem` types to the asset module's interface.

Previously, the `Asset` type returned the metadata entry in the database directly to the frontend using the type `Record<string, unknown>`.

This was problematic for a few reasons:

* In the case of database reference properties, the identifier stored is not, on its own very useful, so the frontend typically had to immediately query for the requested asset in order to display it, adding a lot of complexity to the frontend code and introducing lots of opportunities for n+1 query situations.
* The frontend had to cast `unknown` to the type it was expecting and manipulate it before presenting to the user, which is fragile and makes refactoring difficult.

As the adding of repeated properties would have significantly increased these, we've abstracted the properties returned somewhat, using the following type:

```typescript
export interface AssetMetadataItem<T = unknown> {
  /*
   * The canonical value of the property, as stored in the database.
   *
   * Property values are always repredented using an array in order to allow for consistent treatment of single and
   * repated occurances in the schema.
   *
   * A null value for a non-repeated property implies a rawValue of `[]`.
   * A value for a non-repeated property implies an array of length 1
   * A repeated property will have 0 or more elements.
   */
  rawValue: (T | undefined)[];

  /**
   * For each element in `rawValue`, both the raw value and a human-readable string representation of it.
   */
  presentationValue: { rawValue?: T; label: string }[];
}
```

** Other changes **

* Fixes a previously existing bug that caused the schema editor to disappear when it was edited if the view was scrolled.
* Improves code-level documentation for changes introduced in #42 that we touched in this PR.
* Abstracts some of the test data used in storybook and automated tests out into helper functions to reduce code churn when interfaces are changed
* Slightly tweak the auto-sizing behaviour of columns
 