### PR TITLE
Adds support for displaying html error messages in a modal

### DIFF
--- a/src/app/entry/main.ts
+++ b/src/app/entry/main.ts
@@ -95,7 +95,7 @@ async function main() {
   async function showArchiveWindow(archive: ArchivePackage) {
     const window = await createFrontendWindow({
       title: path.basename(archive.location, path.extname(archive.location)),
-      config: { documentId: archive.id },
+      config: { documentId: archive.id, type: 'archive' },
       resolveMedia: (uri) =>
         media.fileService.resolveRenditionUri(archive, uri),
       router: app.router
@@ -148,7 +148,7 @@ async function main() {
 
     const window = await createFrontendWindow({
       title: 'New Archive',
-      config: {},
+      config: { type: 'splash-screen' },
       router: app.router,
       size: 'small'
     });

--- a/src/common/frontend-config.ts
+++ b/src/common/frontend-config.ts
@@ -9,6 +9,15 @@ export interface FrontendConfig {
   /** If the window represents a document, the id of that document */
   documentId?: string;
 
+  /** The type of window to display */
+  type: 'splash-screen' | 'archive' | 'modal';
+
+  modalConfig?: {
+    message: { __html: string };
+    icon: ModalIcon;
+    returnId: string;
+  };
+
   /** Title of the window */
   title?: string;
 
@@ -20,3 +29,4 @@ export interface FrontendConfig {
 }
 
 export type FrontendPlatform = 'linuxish' | 'mac' | 'windows' | 'web';
+export type ModalIcon = 'error';

--- a/src/common/ui.interfaces.ts
+++ b/src/common/ui.interfaces.ts
@@ -30,6 +30,27 @@ export const MaximizationStateChanged = EventInterface({
   type: MaximizationState
 });
 
+export const ShowModal = RpcInterface({
+  id: 'window/show-modal',
+  request: z.object({
+    title: z.string(),
+    icon: z.string(),
+    message: z.string()
+  }),
+  response: z.object({
+    action: z.enum(['confirm', 'cancel'])
+  })
+});
+
+export const CloseModal = RpcInterface({
+  id: 'window/close-modal',
+  request: z.object({
+    returnId: z.string(),
+    action: z.enum(['confirm', 'cancel'])
+  }),
+  response: z.object({})
+});
+
 export const ShowContextMenu = RpcInterface({
   id: 'window/show-context-menu',
   request: z.object({

--- a/src/frontend/app.tsx
+++ b/src/frontend/app.tsx
@@ -1,19 +1,13 @@
 /** @jsxImportSource theme-ui */
 
-import { useCallback } from 'react';
 import { FC } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { Button, Flex } from 'theme-ui';
-import { OpenArchive } from '../common/interfaces/archive.interfaces';
 
-import { useRPC } from './ipc/ipc.hooks';
 import { ArchiveScreen } from './screens/archive.screen';
 import { CollectionScreen } from './screens/collection.screen';
 import { ArchiveIngestScreen } from './screens/ingest.screen';
-import { InitialScreen } from './screens/initial.screen';
 import { SchemaScreen } from './screens/schema.screen';
 import { InvalidateOnPageChange } from './ui/components/util.component';
-import { WindowInset } from './ui/window';
 
 /**
  * Root component for a window representing an archive
@@ -49,14 +43,3 @@ export const ArchiveWindow: FC<{ title?: string }> = ({ title }) => (
     </Route>
   </Routes>
 );
-
-/**
- * Root component for a window shown on first launch
- */
-export const NewArchiveWindow: FC = () => {
-  return (
-    <>
-      <InitialScreen />
-    </>
-  );
-};

--- a/src/frontend/entry/main.desktop.tsx
+++ b/src/frontend/entry/main.desktop.tsx
@@ -13,9 +13,10 @@ import { FrontendConfigContext } from '../config';
 import { FrontendConfig } from '../../common/frontend-config';
 import { IpcContext } from '../ipc/ipc.hooks';
 import { ElectronRendererIpc } from '../ipc/electron-ipc';
-import { ArchiveWindow, NewArchiveWindow } from '../app';
-import { StrictMode } from 'react';
+import { ReactElement, StrictMode } from 'react';
 import { SelectionContext } from '../ui/hooks/selection.hooks';
+import { never } from '../../common/util/assert';
+import { ModalScreen } from '../screens/modal.screen';
 
 /** Exposed from main process via browser-preload.js */
 declare const bridge: {
@@ -25,32 +26,44 @@ declare const bridge: {
 
 const ipc = new ElectronRendererIpc(bridge.ipcRenderer);
 
-const app = (
-  <StrictMode>
-    <ThemeProvider theme={theme}>
-      <SelectionContext.Provider>
-        <MemoryRouter>
-          <IpcContext.Provider
-            value={{ ipc, documentId: bridge.config.documentId }}
-          >
-            <FrontendConfigContext.Provider value={bridge.config}>
-              <Window>
-                {bridge.config.documentId ? (
-                  <ArchiveWindow title={bridge.config.title} />
-                ) : (
-                  <NewArchiveWindow />
-                )}
-              </Window>
-            </FrontendConfigContext.Provider>
-          </IpcContext.Provider>
-        </MemoryRouter>
-      </SelectionContext.Provider>
-    </ThemeProvider>
-  </StrictMode>
-);
+const renderWindow = (el: ReactElement) => {
+  const app = (
+    <StrictMode>
+      <ThemeProvider theme={theme}>
+        <SelectionContext.Provider>
+          <MemoryRouter>
+            <IpcContext.Provider
+              value={{ ipc, documentId: bridge.config.documentId }}
+            >
+              <FrontendConfigContext.Provider value={bridge.config}>
+                <Window>{el}</Window>
+              </FrontendConfigContext.Provider>
+            </IpcContext.Provider>
+          </MemoryRouter>
+        </SelectionContext.Provider>
+      </ThemeProvider>
+    </StrictMode>
+  );
 
-render(app, document.getElementById('root'), () =>
-  setTimeout(() =>
-    bridge.ipcRenderer.send('render-window', bridge.config.windowId)
-  )
-);
+  render(app, document.getElementById('root'), () =>
+    setTimeout(() =>
+      bridge.ipcRenderer.send('render-window', bridge.config.windowId)
+    )
+  );
+};
+
+if (bridge.config.type === 'splash-screen') {
+  import('../screens/initial.screen').then(({ InitialScreen }) =>
+    renderWindow(<InitialScreen />)
+  );
+} else if (bridge.config.type === 'archive') {
+  import('../app').then(({ ArchiveWindow }) =>
+    renderWindow(<ArchiveWindow title={bridge.config.title} />)
+  );
+} else if (bridge.config.type === 'modal') {
+  import('../screens/modal.screen').then(({ ModalScreen }) =>
+    renderWindow(<ModalScreen />)
+  );
+} else {
+  never(bridge.config.type);
+}

--- a/src/frontend/screens/modal.screen.tsx
+++ b/src/frontend/screens/modal.screen.tsx
@@ -1,0 +1,64 @@
+/** @jsxImportSource theme-ui */
+
+import { Box, Button, Flex, Text } from 'theme-ui';
+import { ExclamationTriangleFill } from 'react-bootstrap-icons';
+
+import { CloseModal } from '../../common/ui.interfaces';
+import { required } from '../../common/util/assert';
+import { useFrontendConfig } from '../config';
+import { useRPC } from '../ipc/ipc.hooks';
+import { WindowDragArea } from '../ui/window';
+
+const icons = {
+  error: (
+    <ExclamationTriangleFill size={48} color="var(--theme-ui-colors-error)" />
+  )
+};
+
+export const ModalScreen = () => {
+  const config = useFrontendConfig();
+  const modalConfig = required(
+    config.modalConfig,
+    'Expected modalConfig to be defined'
+  );
+  const rpc = useRPC();
+
+  const handleConfirm = () => {
+    rpc(CloseModal, { returnId: modalConfig.returnId, action: 'confirm' });
+  };
+
+  return (
+    <Flex
+      sx={{ width: '100vw', height: '100vh', flexDirection: 'column', p: 5 }}
+    >
+      <WindowDragArea
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'center',
+          alignItems: 'center',
+          flexGrow: 1
+        }}
+      >
+        <Box sx={{ pr: 6 }}>{icons[modalConfig.icon]}</Box>
+
+        <Text
+          sx={{ flexGrow: 1 }}
+          dangerouslySetInnerHTML={modalConfig.message}
+        />
+      </WindowDragArea>
+
+      <WindowDragArea
+        sx={{
+          flexDirection: 'row',
+          display: 'flex',
+          justifyContent: 'flex-end'
+        }}
+      >
+        <Button sx={{ px: 5 }} onClick={handleConfirm}>
+          Ok
+        </Button>
+      </WindowDragArea>
+    </Flex>
+  );
+};

--- a/src/frontend/ui/hooks/error.hooks.ts
+++ b/src/frontend/ui/hooks/error.hooks.ts
@@ -1,16 +1,20 @@
+import { ReactElement } from 'react';
+import { useModal } from './modal.hooks';
+
 /**
  * Hook for displaying errors.
  * Currently uses console.error until we get round to presenting them in a nicer way.
  */
 export function useErrorDisplay() {
-  return Object.assign(
-    (error: string) => {
-      console.error(error);
-    },
-    {
-      unexpected: (code: string) => {
-        console.error('Unexpected error', code);
-      }
+  const model = useModal();
+  const error = (error: string | ReactElement) => {
+    model.alert({ message: error, title: 'Error', icon: 'error' });
+  };
+
+  return Object.assign(error, {
+    unexpected: (code: string) => {
+      console.error(error, code);
+      error('An unexpected error occured');
     }
-  );
+  });
 }

--- a/src/frontend/ui/hooks/modal.hooks.ts
+++ b/src/frontend/ui/hooks/modal.hooks.ts
@@ -1,0 +1,29 @@
+import { ReactElement, useMemo } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ModalIcon } from '../../../common/frontend-config';
+import { ShowModal } from '../../../common/ui.interfaces';
+import { useRPC } from '../../ipc/ipc.hooks';
+
+export function useModal() {
+  const rpc = useRPC();
+
+  return useMemo(
+    () => ({
+      alert: async (opts: {
+        message: string | ReactElement;
+        title: string;
+        icon: ModalIcon;
+      }) => {
+        const message =
+          typeof opts.message === 'string'
+            ? opts.message
+            : renderToStaticMarkup(opts.message);
+        const res = await rpc(ShowModal, { ...opts, message });
+        if (res.status === 'error') {
+          throw res.error;
+        }
+      }
+    }),
+    [rpc]
+  );
+}

--- a/src/frontend/ui/window.tsx
+++ b/src/frontend/ui/window.tsx
@@ -100,6 +100,7 @@ export const WindowDragArea: FC<HTMLAttributes<unknown>> = (props) => (
 );
 
 const WindowControls = () => {
+  const config = useFrontendConfig();
   const rpc = useRPC();
   const [state, setState] = useState<MaximizationState>();
 
@@ -122,6 +123,10 @@ const WindowControls = () => {
     () => rpc(ToggleMaximizeWindow, {}),
     [rpc]
   );
+
+  if (config.type === 'modal') {
+    return null;
+  }
 
   if (!state) {
     return null;
@@ -150,77 +155,81 @@ const WindowControls = () => {
         }
       }}
     >
-      <div role="button" onClick={minimize}>
-        <img
-          srcSet={`${windowsIcon(
-            './icons/windows/min-w-10.png'
-          )} 1x, ${windowsIcon(
-            './icons/windows/min-w-12.png'
-          )} 1.25x, ${windowsIcon(
-            './icons/windows/min-w-15.png'
-          )} 1.5x, ${windowsIcon(
-            './icons/windows/min-w-15.png'
-          )} 1.75x, ${windowsIcon(
-            './icons/windows/min-w-20.png'
-          )} 2x, ${windowsIcon(
-            './icons/windows/min-w-20.png'
-          )} 2.25x, ${windowsIcon(
-            './icons/windows/min-w-24.png'
-          )} 2.5x, ${windowsIcon(
-            './icons/windows/min-w-30.png'
-          )} 3x, ${windowsIcon('./icons/windows/min-w-30.png')} 3.5x`}
-          draggable="false"
-        />
-      </div>
+      {config.type === 'archive' && (
+        <>
+          <div role="button" onClick={minimize}>
+            <img
+              srcSet={`${windowsIcon(
+                './icons/windows/min-w-10.png'
+              )} 1x, ${windowsIcon(
+                './icons/windows/min-w-12.png'
+              )} 1.25x, ${windowsIcon(
+                './icons/windows/min-w-15.png'
+              )} 1.5x, ${windowsIcon(
+                './icons/windows/min-w-15.png'
+              )} 1.75x, ${windowsIcon(
+                './icons/windows/min-w-20.png'
+              )} 2x, ${windowsIcon(
+                './icons/windows/min-w-20.png'
+              )} 2.25x, ${windowsIcon(
+                './icons/windows/min-w-24.png'
+              )} 2.5x, ${windowsIcon(
+                './icons/windows/min-w-30.png'
+              )} 3x, ${windowsIcon('./icons/windows/min-w-30.png')} 3.5x`}
+              draggable="false"
+            />
+          </div>
 
-      {state !== 'maximized' && (
-        <div role="button" onClick={toggleMaximize}>
-          <img
-            srcSet={`${windowsIcon(
-              './icons/windows/max-w-10.png'
-            )} 1x, ${windowsIcon(
-              './icons/windows/max-w-12.png'
-            )} 1.25x, ${windowsIcon(
-              './icons/windows/max-w-15.png'
-            )} 1.5x, ${windowsIcon(
-              './icons/windows/max-w-15.png'
-            )} 1.75x, ${windowsIcon(
-              './icons/windows/max-w-20.png'
-            )} 2x, ${windowsIcon(
-              './icons/windows/max-w-20.png'
-            )} 2.25x, ${windowsIcon(
-              './icons/windows/max-w-24.png'
-            )} 2.5x, ${windowsIcon(
-              './icons/windows/max-w-30.png'
-            )} 3x, ${windowsIcon('./icons/windows/max-w-30.png')} 3.5x`}
-            draggable="false"
-          />
-        </div>
-      )}
+          {state !== 'maximized' && (
+            <div role="button" onClick={toggleMaximize}>
+              <img
+                srcSet={`${windowsIcon(
+                  './icons/windows/max-w-10.png'
+                )} 1x, ${windowsIcon(
+                  './icons/windows/max-w-12.png'
+                )} 1.25x, ${windowsIcon(
+                  './icons/windows/max-w-15.png'
+                )} 1.5x, ${windowsIcon(
+                  './icons/windows/max-w-15.png'
+                )} 1.75x, ${windowsIcon(
+                  './icons/windows/max-w-20.png'
+                )} 2x, ${windowsIcon(
+                  './icons/windows/max-w-20.png'
+                )} 2.25x, ${windowsIcon(
+                  './icons/windows/max-w-24.png'
+                )} 2.5x, ${windowsIcon(
+                  './icons/windows/max-w-30.png'
+                )} 3x, ${windowsIcon('./icons/windows/max-w-30.png')} 3.5x`}
+                draggable="false"
+              />
+            </div>
+          )}
 
-      {state === 'maximized' && (
-        <div role="button" onClick={toggleMaximize}>
-          <img
-            srcSet={`${windowsIcon(
-              './icons/windows/restore-w-10.png'
-            )} 1x, ${windowsIcon(
-              './icons/windows/restore-w-12.png'
-            )} 1.25x, ${windowsIcon(
-              './icons/windows/restore-w-15.png'
-            )} 1.5x, ${windowsIcon(
-              './icons/windows/restore-w-15.png'
-            )} 1.75x, ${windowsIcon(
-              './icons/windows/restore-w-20.png'
-            )} 2x, ${windowsIcon(
-              './icons/windows/restore-w-20.png'
-            )} 2.25x, ${windowsIcon(
-              './icons/windows/restore-w-24.png'
-            )} 2.5x, ${windowsIcon(
-              './icons/windows/restore-w-30.png'
-            )} 3x, ${windowsIcon('./icons/windows/restore-w-30.png')} 3.5x`}
-            draggable="false"
-          />
-        </div>
+          {state === 'maximized' && (
+            <div role="button" onClick={toggleMaximize}>
+              <img
+                srcSet={`${windowsIcon(
+                  './icons/windows/restore-w-10.png'
+                )} 1x, ${windowsIcon(
+                  './icons/windows/restore-w-12.png'
+                )} 1.25x, ${windowsIcon(
+                  './icons/windows/restore-w-15.png'
+                )} 1.5x, ${windowsIcon(
+                  './icons/windows/restore-w-15.png'
+                )} 1.75x, ${windowsIcon(
+                  './icons/windows/restore-w-20.png'
+                )} 2x, ${windowsIcon(
+                  './icons/windows/restore-w-20.png'
+                )} 2.25x, ${windowsIcon(
+                  './icons/windows/restore-w-24.png'
+                )} 2.5x, ${windowsIcon(
+                  './icons/windows/restore-w-30.png'
+                )} 3x, ${windowsIcon('./icons/windows/restore-w-30.png')} 3.5x`}
+                draggable="false"
+              />
+            </div>
+          )}
+        </>
       )}
 
       <div role="button" onClick={window.close}>


### PR DESCRIPTION
This PR adds support for displaying error messages in a modal window:

<img width="1132" alt="Screenshot 2022-05-18 at 15 56 25" src="https://user-images.githubusercontent.com/361391/169072304-1236a7aa-2bf0-4803-91d1-870ea9cd63bb.png">

The API allows callers to launch a new window displaying some HTML (rendered from react) that presents information to the user. The caller then awaits a promise for the window to close, then returns.

In the process of doing this, we refactor the app entrypoint a bit to make support for different inital views a bit cleaner.

This potentially also interesting a first step towards a more multi-window UI, so interested in feedback on the API for 'modal' use cases (perhaps instead of providing some HTML to render, the caller could provide the path to a route to display).