### PR TITLE
Support for deleting assets from the archive

### DIFF
--- a/src/app/asset/__tests__/asset.spec.ts
+++ b/src/app/asset/__tests__/asset.spec.ts
@@ -8,7 +8,12 @@ import { getTempfiles, getTempPackage } from '../../../test/tempfile';
 import { MediaFileService } from '../../media/media-file.service';
 import { AssetsChangedEvent, AssetService } from '../asset.service';
 import { CollectionService } from '../collection.service';
-import { assetMetadata } from '../test-utils';
+import {
+  assetMetadata,
+  assetMetadataItem,
+  assetMetadataItemMatcher,
+  someSchemaProperty
+} from '../test-utils';
 
 const SCHEMA: SchemaProperty[] = [
   {
@@ -305,6 +310,147 @@ describe(AssetService, () => {
         );
         expect(dbAssets.total).toBe(0);
         expect(res).toBeUndefined();
+      });
+    });
+  });
+
+  describe('deleting assets', () => {
+    it('should not allow deletion of assets that are referenced by a single required property', async () => {
+      const fixture = await setup();
+
+      const targetDb = await fixture.givenAControlledDatabaseWithSchema([]);
+
+      const [dbProperty] = await fixture.givenTheSchema([
+        someSchemaProperty({
+          type: SchemaPropertyType.CONTROLLED_DATABASE,
+          required: true,
+          databaseId: targetDb.id
+        })
+      ]);
+
+      const targetRecord = requireSuccess(
+        await fixture.service.createAsset(fixture.archive, targetDb.id, {
+          metadata: {}
+        })
+      );
+      const referencingRecord = requireSuccess(
+        await fixture.service.createAsset(
+          fixture.archive,
+          fixture.rootCollection.id,
+          { metadata: { [dbProperty.id]: [targetRecord.id] } }
+        )
+      );
+
+      expect(
+        await fixture.service.deleteAssets(fixture.archive, targetDb.id, [
+          targetRecord.id
+        ])
+      ).toEqual({
+        status: 'error',
+        error: expect.arrayContaining([
+          expect.objectContaining({
+            assetId: referencingRecord.id
+          })
+        ])
+      });
+
+      expect(
+        await fixture.service.listAssets(fixture.archive, targetDb.id)
+      ).toHaveProperty('total', 1);
+    });
+
+    it('should remove references from non-required properties from the related record', async () => {
+      const fixture = await setup();
+
+      const targetDb = await fixture.givenAControlledDatabaseWithSchema([]);
+
+      const [dbProperty] = await fixture.givenTheSchema([
+        someSchemaProperty({
+          type: SchemaPropertyType.CONTROLLED_DATABASE,
+          required: false,
+          databaseId: targetDb.id
+        })
+      ]);
+
+      const targetRecord = requireSuccess(
+        await fixture.service.createAsset(fixture.archive, targetDb.id, {
+          metadata: {}
+        })
+      );
+
+      const referencingRecord = requireSuccess(
+        await fixture.service.createAsset(
+          fixture.archive,
+          fixture.rootCollection.id,
+          { metadata: { [dbProperty.id]: [targetRecord.id] } }
+        )
+      );
+
+      requireSuccess(
+        await fixture.service.deleteAssets(fixture.archive, targetDb.id, [
+          targetRecord.id
+        ])
+      );
+
+      expect(
+        await fixture.service.listAssets(fixture.archive, targetDb.id)
+      ).toHaveProperty('total', 0);
+
+      expect(
+        await fixture.service.get(fixture.archive, referencingRecord.id)
+      ).toHaveProperty('metadata', {
+        [dbProperty.id]: assetMetadataItemMatcher([])
+      });
+    });
+
+    it('should remove references from required properties from the related record where there would still be a remaining property', async () => {
+      const fixture = await setup();
+
+      const targetDb = await fixture.givenAControlledDatabaseWithSchema([]);
+
+      const [dbProperty] = await fixture.givenTheSchema([
+        someSchemaProperty({
+          type: SchemaPropertyType.CONTROLLED_DATABASE,
+          required: true,
+          repeated: true,
+          databaseId: targetDb.id
+        })
+      ]);
+
+      const targetRecord = requireSuccess(
+        await fixture.service.createAsset(fixture.archive, targetDb.id, {
+          metadata: {}
+        })
+      );
+
+      const anotherRecord = requireSuccess(
+        await fixture.service.createAsset(fixture.archive, targetDb.id, {
+          metadata: {}
+        })
+      );
+
+      const referencingRecord = requireSuccess(
+        await fixture.service.createAsset(
+          fixture.archive,
+          fixture.rootCollection.id,
+          { metadata: { [dbProperty.id]: [targetRecord.id, anotherRecord.id] } }
+        )
+      );
+
+      requireSuccess(
+        await fixture.service.deleteAssets(fixture.archive, targetDb.id, [
+          targetRecord.id
+        ])
+      );
+
+      expect(
+        await fixture.service.listAssets(fixture.archive, targetDb.id)
+      ).toHaveProperty('total', 1);
+
+      expect(
+        await fixture.service.get(fixture.archive, referencingRecord.id)
+      ).toHaveProperty('metadata', {
+        [dbProperty.id]: assetMetadataItemMatcher([anotherRecord.id])
       });
     });
   });

--- a/src/app/asset/asset.init.ts
+++ b/src/app/asset/asset.init.ts
@@ -59,8 +59,8 @@ export function initAssets(router: ElectronRouter, media: MediaFileService) {
     }
   );
 
-  router.bindArchiveRpc(DeleteAssets, (archive, { assetIds, collectionId }) => {
-    return assetService.deleteAssets(archive, collectionId, assetIds);
+  router.bindArchiveRpc(DeleteAssets, (archive, { assetIds }) => {
+    return assetService.deleteAssets(archive, assetIds);
   });
 
   router.bindArchiveRpc(

--- a/src/app/asset/asset.init.ts
+++ b/src/app/asset/asset.init.ts
@@ -10,7 +10,8 @@ import {
   UpdateCollection,
   CreateAsset,
   GetAsset,
-  SearchAsset
+  SearchAsset,
+  DeleteAssets
 } from '../../common/asset.interfaces';
 import { ChangeEvent } from '../../common/resource';
 import { ok, okIfExists } from '../../common/util/error';
@@ -58,6 +59,10 @@ export function initAssets(router: ElectronRouter, media: MediaFileService) {
     }
   );
 
+  router.bindArchiveRpc(DeleteAssets, (archive, { assetIds, collectionId }) => {
+    return assetService.deleteAssets(archive, collectionId, assetIds);
+  });
+
   router.bindArchiveRpc(
     CreateCollection,
     async (archive, { parent, ...props }) =>
@@ -94,8 +99,16 @@ export function initAssets(router: ElectronRouter, media: MediaFileService) {
     );
   });
 
-  assetService.on('change', ({ created }) => {
-    router.emit(ChangeEvent, { type: ListAssets.id, ids: [...created] });
+  assetService.on('change', ({ updated }) => {
+    router.emit(ChangeEvent, {
+      type: ListAssets.id,
+      ids: []
+    });
+
+    router.emit(ChangeEvent, {
+      type: GetAsset.id,
+      ids: updated
+    });
   });
 
   collectionService.on('change', ({ created, updated, deleted }) => {

--- a/src/app/asset/asset.service.ts
+++ b/src/app/asset/asset.service.ts
@@ -17,7 +17,7 @@ import { ArchivePackage } from '../package/archive-package';
 import { AssetCollectionEntity, AssetEntity } from './asset.entity';
 import { CollectionService } from './collection.service';
 import { SchemaPropertyValue } from './metadata.entity';
-import { never } from '../../common/util/assert';
+import { never, required } from '../../common/util/assert';
 
 interface CreateAssetOpts {
   /** Metadata to associate with the asset. This must be valid according to the archive schema */
@@ -389,9 +389,20 @@ export class AssetService extends EventEmitter<AssetEvents> {
             property.required &&
             reference.metadata[property.id]?.length === 1
           ) {
+            const asset = required(
+              await this.get(archive, reference.id),
+              'Cannot resolve entity by id'
+            );
+
             errors.push({
               assetId: reference.id,
-              collectionId: collection.id
+              collectionId: collection.id,
+              collectionTitle: collection.title,
+              propertyId: property.id,
+              propertyLabel:
+                collection.schema.find((x) => x.id === property.id)?.label ??
+                property.id,
+              assetTitle: asset.title
             });
           } else {
             const propertyVal = reference.metadata[property.id];

--- a/src/app/asset/collection.service.ts
+++ b/src/app/asset/collection.service.ts
@@ -286,6 +286,24 @@ export class CollectionService extends EventEmitter<CollectionEvents> {
     return res.success;
   }
 
+  async findPropertiesReferencingCollection(
+    archive: ArchivePackage,
+    referencedCollectionId: string
+  ) {
+    const allCollections = await archive.useDb((db) =>
+      db.find(AssetCollectionEntity, {})
+    );
+
+    return allCollections.flatMap((collection) => {
+      return collection.schema
+        .filter(
+          (property) =>
+            property.referencedCollectionId() === referencedCollectionId
+        )
+        .map((property) => ({ property, collection }));
+    });
+  }
+
   /**
    * Validate a that a proposed addition into the archive is valid according to a schema.
    *

--- a/src/app/asset/collection.service.ts
+++ b/src/app/asset/collection.service.ts
@@ -286,6 +286,13 @@ export class CollectionService extends EventEmitter<CollectionEvents> {
     return res.success;
   }
 
+  /**
+   * For a given collection, return all the properties (and their collection instance) that reference it.
+   *
+   * @param archive Archive containing the collection
+   * @param referencedCollectionId Collection to check for referencing properties
+   * @returns Object of { property, collection } values for each referencing property
+   */
   async findPropertiesReferencingCollection(
     archive: ArchivePackage,
     referencedCollectionId: string

--- a/src/app/asset/metadata.entity.ts
+++ b/src/app/asset/metadata.entity.ts
@@ -92,6 +92,14 @@ export abstract class SchemaPropertyValue {
   ): Promise<AssetMetadataItem>;
 
   /**
+   *
+   * @returns
+   */
+  referencedCollectionId(): string | undefined {
+    return undefined;
+  }
+
+  /**
    * Return a zod validator object for this schema property.
    */
   async getValidator(context: CollectionContext) {
@@ -216,6 +224,10 @@ export class ControlledDatabaseSchemaPropertyValue
         });
       }
     });
+  }
+
+  referencedCollectionId(): string | undefined {
+    return this.databaseId;
   }
 
   async castValue(value: unknown, { archive, assets }: AssetContext) {

--- a/src/app/asset/test-utils.ts
+++ b/src/app/asset/test-utils.ts
@@ -18,6 +18,36 @@ export const someAsset = (props: Partial<Asset> = {}): Asset => ({
   ...props
 });
 
+export const someSchemaProperty = (
+  props: Partial<SchemaProperty> = {}
+): SchemaProperty => {
+  const base = {
+    id: faker.datatype.uuid(),
+    label: faker.word.noun(),
+    required: false,
+    repeated: false
+  };
+
+  if (!props.type || props.type === SchemaPropertyType.FREE_TEXT) {
+    return {
+      ...base,
+      ...props,
+      type: SchemaPropertyType.FREE_TEXT
+    };
+  }
+
+  if (props.type === SchemaPropertyType.CONTROLLED_DATABASE) {
+    return {
+      databaseId: faker.datatype.uuid(),
+      ...base,
+      ...props,
+      type: SchemaPropertyType.CONTROLLED_DATABASE
+    };
+  }
+
+  return never(props.type);
+};
+
 export const somePropertyFromASchema = (
   schema: SchemaProperty
 ): AssetMetadataItem => {
@@ -64,4 +94,15 @@ export const assetMetadataItem = (rawValue: unknown[]): AssetMetadataItem => ({
     rawValue: val,
     label: String(val)
   }))
+});
+
+export const assetMetadataItemMatcher = (
+  rawValue: unknown[]
+): AssetMetadataItem => ({
+  rawValue,
+  presentationValue: rawValue.map((val) =>
+    expect.objectContaining({
+      rawValue: val
+    })
+  )
 });

--- a/src/app/electron/config.ts
+++ b/src/app/electron/config.ts
@@ -95,7 +95,7 @@ const DEFAULT_FRONTEND_ENTRYPOINT = FRONTEND_BUNDLE_DIR
   : 'http://localhost:3000/desktop.html';
 
 /** Enable developer tools */
-export const SHOW_DEVTOOLS = parseRuntimeFlag('SHOW_DEVTOOLS', isDev);
+export const SHOW_DEVTOOLS = parseRuntimeFlag('SHOW_DEVTOOLS', false);
 
 /** Enable developer tools */
 export const HIDE_UNTIL_RENDER = parseRuntimeFlag('HIDE_UNTIL_RENDER', !isDev);

--- a/src/app/electron/config.ts
+++ b/src/app/electron/config.ts
@@ -95,7 +95,7 @@ const DEFAULT_FRONTEND_ENTRYPOINT = FRONTEND_BUNDLE_DIR
   : 'http://localhost:3000/desktop.html';
 
 /** Enable developer tools */
-export const SHOW_DEVTOOLS = parseRuntimeFlag('SHOW_DEVTOOLS', false);
+export const SHOW_DEVTOOLS = parseRuntimeFlag('SHOW_DEVTOOLS', isDev);
 
 /** Enable developer tools */
 export const HIDE_UNTIL_RENDER = parseRuntimeFlag('HIDE_UNTIL_RENDER', !isDev);

--- a/src/app/electron/window.ts
+++ b/src/app/electron/window.ts
@@ -6,7 +6,11 @@ import { platform } from 'os';
 import path from 'path';
 import { URL } from 'url';
 
-import { FrontendConfig, ModalIcon } from '../../common/frontend-config';
+import {
+  FrontendConfig,
+  ModalIcon,
+  ModalType
+} from '../../common/frontend-config';
 import {
   GetMaximizationState,
   MaximizationState,
@@ -327,7 +331,10 @@ export async function initWindows(router: ElectronRouter) {
         title: req.title,
         modalConfig: {
           message: { __html: req.message },
+          type: req.type as ModalType,
           icon: req.icon as ModalIcon,
+          confirmButtonLabel: req.confirmButtonLabel,
+          cancelButtonLabel: req.cancelButtonLabel,
           returnId
         }
       }

--- a/src/common/asset.interfaces.ts
+++ b/src/common/asset.interfaces.ts
@@ -108,7 +108,11 @@ export type AggregatedValidationError = z.TypeOf<
 export const ReferentialIntegrityError = z.array(
   z.object({
     assetId: z.string(),
-    collectionId: z.string()
+    assetTitle: z.string().optional(),
+    collectionId: z.string(),
+    collectionTitle: z.string(),
+    propertyId: z.string(),
+    propertyLabel: z.string()
   })
 );
 export type ReferentialIntegrityError = z.TypeOf<

--- a/src/common/asset.interfaces.ts
+++ b/src/common/asset.interfaces.ts
@@ -316,7 +316,6 @@ export const SearchAsset = RpcInterface({
 export const DeleteAssets = RpcInterface({
   id: 'assets/delete',
   request: z.object({
-    collectionId: z.string(),
     assetIds: z.array(z.string())
   }),
   response: z.object({}),

--- a/src/common/asset.interfaces.ts
+++ b/src/common/asset.interfaces.ts
@@ -294,7 +294,7 @@ export const CreateAsset = RpcInterface({
 });
 
 /**
- * Create a new asset.
+ * Search for an asset by part of its title.
  */
 export const SearchAsset = RpcInterface({
   id: 'assets/search',
@@ -304,6 +304,19 @@ export const SearchAsset = RpcInterface({
   }),
   response: ResourceList(Asset),
   error: z.nativeEnum(FetchError)
+});
+
+/**
+ * Delete one or more assets.
+ */
+export const DeleteAssets = RpcInterface({
+  id: 'assets/delete',
+  request: z.object({
+    collectionId: z.string(),
+    assetIds: z.array(z.string())
+  }),
+  response: z.object({}),
+  error: z.nativeEnum(FetchError).or(ReferentialIntegrityError)
 });
 
 /**

--- a/src/common/frontend-config.ts
+++ b/src/common/frontend-config.ts
@@ -16,6 +16,9 @@ export interface FrontendConfig {
     message: { __html: string };
     icon: ModalIcon;
     returnId: string;
+    type: ModalType;
+    confirmButtonLabel?: string;
+    cancelButtonLabel?: string;
   };
 
   /** Title of the window */
@@ -29,4 +32,5 @@ export interface FrontendConfig {
 }
 
 export type FrontendPlatform = 'linuxish' | 'mac' | 'windows' | 'web';
-export type ModalIcon = 'error';
+export type ModalIcon = 'error' | 'question';
+export type ModalType = 'alert' | 'confirm';

--- a/src/common/ui.interfaces.ts
+++ b/src/common/ui.interfaces.ts
@@ -33,9 +33,12 @@ export const MaximizationStateChanged = EventInterface({
 export const ShowModal = RpcInterface({
   id: 'window/show-modal',
   request: z.object({
+    type: z.string(),
     title: z.string(),
     icon: z.string(),
-    message: z.string()
+    message: z.string(),
+    confirmButtonLabel: z.string().optional(),
+    cancelButtonLabel: z.string().optional()
   }),
   response: z.object({
     action: z.enum(['confirm', 'cancel'])

--- a/src/frontend/screens/collection.screen.tsx
+++ b/src/frontend/screens/collection.screen.tsx
@@ -190,7 +190,7 @@ const useAssetContextMenu = (collectionId: string) => {
         id: 'delete',
         label: 'Delete',
         action: async () => {
-          const res = await rpc(DeleteAssets, { assetIds, collectionId });
+          const res = await rpc(DeleteAssets, { assetIds });
 
           if (res.status === 'error') {
             if (typeof res.error === 'object') {

--- a/src/frontend/screens/collection.screen.tsx
+++ b/src/frontend/screens/collection.screen.tsx
@@ -3,6 +3,7 @@
 import { FC, useCallback, useMemo, useState } from 'react';
 import {
   Asset,
+  DeleteAssets,
   GetCollection,
   ListAssets,
   SchemaProperty
@@ -13,7 +14,8 @@ import {
   ListCursor,
   unwrapGetResult,
   useGet,
-  useList
+  useList,
+  useRPC
 } from '../ipc/ipc.hooks';
 import { DataGrid, GridColumn } from '../ui/components/grid.component';
 import { AssetDetail } from '../ui/components/asset-detail.component';
@@ -27,16 +29,20 @@ import { useContextMenu } from '../ui/hooks/menu.hooks';
 import { IconButton } from 'theme-ui';
 import { Gear, Plus } from 'react-bootstrap-icons';
 import { MetadataItemCell } from '../ui/components/grid-cell.component';
+import { useErrorDisplay } from '../ui/hooks/error.hooks';
 
 /**
  * Screen for viewing the assets in a collection.
  */
 export const CollectionScreen: FC = () => {
+  const errors = useErrorDisplay();
+  const navigate = useNavigate();
+  const rpc = useRPC();
+
   const collectionId = required(
     useParams().collectionId,
     'Expected collectionId param'
   );
-  const navigate = useNavigate();
   const collection = unwrapGetResult(useGet(GetCollection, collectionId));
   const fetchedAssets = useList(
     ListAssets,
@@ -138,6 +144,15 @@ export const CollectionScreen: FC = () => {
           sx={{ flex: 1, width: '100%' }}
           columns={gridColumns}
           data={assets}
+          contextMenuItems={(assetIds) => [
+            assetIds.length > 0 && {
+              id: 'delete',
+              label: 'Delete',
+              action: async () => {
+                await rpc(DeleteAssets, { assetIds, collectionId });
+              }
+            }
+          ]}
         />
 
         <BottomBar

--- a/src/frontend/screens/modal.screen.tsx
+++ b/src/frontend/screens/modal.screen.tsx
@@ -1,7 +1,10 @@
 /** @jsxImportSource theme-ui */
 
 import { Box, Button, Flex, Text } from 'theme-ui';
-import { ExclamationTriangleFill } from 'react-bootstrap-icons';
+import {
+  ExclamationTriangleFill,
+  QuestionCircleFill
+} from 'react-bootstrap-icons';
 
 import { CloseModal } from '../../common/ui.interfaces';
 import { required } from '../../common/util/assert';
@@ -12,6 +15,9 @@ import { WindowDragArea } from '../ui/window';
 const icons = {
   error: (
     <ExclamationTriangleFill size={48} color="var(--theme-ui-colors-error)" />
+  ),
+  question: (
+    <QuestionCircleFill size={48} color="var(--theme-ui-colors-primary)" />
   )
 };
 
@@ -25,6 +31,10 @@ export const ModalScreen = () => {
 
   const handleConfirm = () => {
     rpc(CloseModal, { returnId: modalConfig.returnId, action: 'confirm' });
+  };
+
+  const handleCancel = () => {
+    rpc(CloseModal, { returnId: modalConfig.returnId, action: 'cancel' });
   };
 
   return (
@@ -55,8 +65,14 @@ export const ModalScreen = () => {
           justifyContent: 'flex-end'
         }}
       >
+        {modalConfig.type === 'confirm' && (
+          <Button sx={{ px: 5, mr: 4 }} onClick={handleCancel}>
+            {modalConfig.cancelButtonLabel ?? 'Cancel'}
+          </Button>
+        )}
+
         <Button sx={{ px: 5 }} onClick={handleConfirm}>
-          Ok
+          {modalConfig.confirmButtonLabel ?? 'Ok'}
         </Button>
       </WindowDragArea>
     </Flex>

--- a/src/frontend/ui/components/page-layouts.component.tsx
+++ b/src/frontend/ui/components/page-layouts.component.tsx
@@ -143,9 +143,9 @@ export const NavListItem: FC<NavListItemProps> = ({
       ref={wrapperRef}
       tabIndex={0}
       sx={{
-        outline:
+        variant:
           !isActive && (editing || contextMenu.visible)
-            ? '2px solid var(--theme-ui-colors-muted)'
+            ? 'listItems.active'
             : undefined,
         flexDirection: 'row',
         alignItems: 'center',

--- a/src/frontend/ui/hooks/menu.hooks.ts
+++ b/src/frontend/ui/hooks/menu.hooks.ts
@@ -9,13 +9,13 @@ import {
 import { ShowContextMenu } from '../../../common/ui.interfaces';
 import { useRPC } from '../../ipc/ipc.hooks';
 
-interface ContextMenuItem {
+export interface ContextMenuItem {
   id: string;
   label: string;
   action: () => void;
 }
 
-type ContextMenuChoice = ContextMenuItem | '-' | undefined;
+export type ContextMenuChoice = ContextMenuItem | '-' | false | undefined;
 
 interface ContextMenuOpts {
   /** Menu options */

--- a/src/frontend/ui/hooks/modal.hooks.ts
+++ b/src/frontend/ui/hooks/modal.hooks.ts
@@ -14,16 +14,38 @@ export function useModal() {
         title: string;
         icon: ModalIcon;
       }) => {
-        const message =
-          typeof opts.message === 'string'
-            ? opts.message
-            : renderToStaticMarkup(opts.message);
-        const res = await rpc(ShowModal, { ...opts, message });
+        const res = await rpc(ShowModal, {
+          ...opts,
+          type: 'alert',
+          message: convertMessage(opts.message)
+        });
         if (res.status === 'error') {
           throw res.error;
         }
+      },
+      confirm: async (opts: {
+        message: string | ReactElement;
+        title: string;
+        icon?: ModalIcon;
+        confirmButtonLabel?: string;
+        cancelButtonLabel?: string;
+      }) => {
+        const res = await rpc(ShowModal, {
+          icon: 'question',
+          type: 'confirm',
+          ...opts,
+          message: convertMessage(opts.message)
+        });
+        if (res.status === 'error') {
+          throw res.error;
+        }
+
+        return res.value.action === 'cancel' ? false : true;
       }
     }),
     [rpc]
   );
 }
+
+const convertMessage = (message: string | ReactElement) =>
+  typeof message === 'string' ? message : renderToStaticMarkup(message);

--- a/src/frontend/ui/theme.ts
+++ b/src/frontend/ui/theme.ts
@@ -1,4 +1,4 @@
-import { Theme } from 'theme-ui';
+import { Theme, ThemeUIStyleObject } from 'theme-ui';
 import * as polished from 'polished';
 import { Scale } from '@theme-ui/css';
 import { Dict } from '../../common/util/types';
@@ -27,224 +27,232 @@ const colors = {
 const scaleGet = <T>(scale: Scale<T> | undefined, key: string | number) =>
   scale ? ((scale as Dict<T>)[key] as T | undefined) : undefined;
 
-export const theme: Theme = {
-  config: {
-    useCustomProperties: true,
-    initialColorModeName: 'system',
-    useRootStyles: true,
-    useBorderBox: true,
-    useLocalStorage: false
-  },
-  space: [0, 3, 5, 8, 13, 21, 34],
-  colors: {
-    ...colors,
-    text: 'black',
-    success: colors.green,
-    error: polished.setHue(0, colors.green),
-    warn: polished.setHue(26, colors.green),
-    border: colors.gray,
-    highlight: colors.charcoal,
-    highlightHint: polished.transparentize(0.8, colors.charcoal),
-    highlightContrast: 'white',
-    background: colors.gray2,
-    foreground: 'white',
-    primary: colors.blue,
-    primaryContrast: 'white',
-    secondary: '#81683E',
-    accent: '#008FFF',
-    muted: '#818B88'
-  },
-  borders: {
-    primary: '2px solid var(--theme-ui-colors-border)',
-    selected: '2px solid var(--theme-ui-colors-accent)'
-  },
-  radii: {
-    control: 5
-  },
-  shadows: {
-    vertical: '0px 2px 10px 2px rgba(0,0,0,0.1)',
-    medium: '0px 1px 10px 2px rgba(0,0,0,0.1)',
-    raised: '1px 2px 15px 2px rgba(0,0,0,0.15)',
-    selected: '0 0 0 2px var(--theme-ui-colors-accent)'
-  },
-  fonts: {
-    body: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
-    heading:
-      'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
-    monospace: 'Menlo, monospace'
-  },
-  fontSizes: [12, 14, 16, 20, 24, 32, 48, 64, 72],
-  fontWeights: {
-    body: 400,
-    heading: 400,
-    display: 600
-  },
-  lineHeights: {
-    body: 1.5,
-    heading: 1.25
-  },
-  forms: {
-    label: {
-      fontSize: 1,
-      paddingBottom: 2,
-      fontWeight: 600
+export const theme: Theme & { listItems?: Record<string, ThemeUIStyleObject> } =
+  {
+    config: {
+      useCustomProperties: true,
+      initialColorModeName: 'system',
+      useRootStyles: true,
+      useBorderBox: true,
+      useLocalStorage: false
     },
-    select: {
-      boxSizing: 'border-box',
-      margin: 0,
-      minWidth: 0,
-      display: 'block',
-      width: '100%',
-      padding: '5px',
-      appearance: 'none',
-      fontSize: 'inherit',
-      lineHeight: 'inherit',
-      border: '1px solid',
-      borderRadius: '4px',
-      color: 'inherit',
-      backgroundColor: 'var(--theme-ui-colors-background)'
-    }
-  },
-  text: {
-    heading: (theme) => ({
-      fontFamily: scaleGet(theme.fonts, 'heading'),
-      fontWeight: scaleGet(theme.fontWeights, 'heading'),
-      lineHeight: scaleGet(theme.lineHeights, 'heading')
-    }),
-    display: () => ({
-      variant: 'heading',
-      fontSize: [5, 6],
-      fontWeight: 'display',
-      letterSpacing: '-0.03em',
-      mt: 3
-    }),
-    section: (theme) => ({
-      textTransform: 'uppercase',
-      fontWeight: 700,
-      fontSize: 0,
-      color: 'grey',
-      letterSpacing: 0.95
-    })
-  },
-  images: {
-    selectable: {
-      padding: '1.5px',
-      borderRadius: 3
-    }
-  },
-  buttons: {
-    primary: (theme) => ({
-      ...controlHover,
-      fontSize: 1,
-      padding: 3,
-      paddingLeft: 4,
-      paddingRight: 4,
-      color: scaleGet(theme.colors, 'primaryContrast'),
-      backgroundColor: scaleGet(theme.fonts, 'primary'),
-      borderRadius: scaleGet(theme.radii, 'control'),
-      '&:disabled': {
-        bg: scaleGet(theme.colors, 'muted')
-      }
-    }),
-    icon: {
-      ...controlHover
+    space: [0, 3, 5, 8, 13, 21, 34],
+    colors: {
+      ...colors,
+      text: 'black',
+      success: colors.green,
+      error: polished.setHue(0, colors.green),
+      warn: polished.setHue(26, colors.green),
+      border: colors.gray,
+      highlight: colors.charcoal,
+      highlightHint: polished.transparentize(0.8, colors.charcoal),
+      highlightContrast: 'white',
+      background: colors.gray2,
+      foreground: 'white',
+      primary: colors.blue,
+      primaryContrast: 'white',
+      secondary: '#81683E',
+      accent: '#008FFF',
+      muted: '#818B88'
     },
-    secondary: (theme) => ({
-      ...controlHover,
-      color: scaleGet(theme.colors, 'background'),
-      bg: scaleGet(theme.colors, 'secondary')
-    }),
-    primaryTransparent: (theme) => ({
-      ...controlHover,
-      color: scaleGet(theme.fonts, 'body'),
-      backgroundColor: scaleGet(theme.colors, 'transparent')
-    })
-  },
-  styles: {
-    Container: {
-      p: 3,
-      maxWidth: 1024
+    borders: {
+      primary: '2px solid var(--theme-ui-colors-border)',
+      active: '2px solid var(--theme-ui-colors-muted)',
+      selected: '2px solid var(--theme-ui-colors-accent)'
     },
-    root: (theme) => ({
-      fontFamily: scaleGet(theme.fonts, 'body'),
-      lineHeight: scaleGet(theme.lineHeights, 'body'),
-      fontWeight: scaleGet(theme.fontWeights, 'body')
-    }),
-    h1: {
-      variant: 'text.display'
+    radii: {
+      control: 5
     },
-    h2: {
-      variant: 'text.heading',
-      fontSize: 5
+    shadows: {
+      vertical: '0px 2px 10px 2px rgba(0,0,0,0.1)',
+      medium: '0px 1px 10px 2px rgba(0,0,0,0.1)',
+      raised: '1px 2px 15px 2px rgba(0,0,0,0.15)',
+      selected: '0 0 0 2px var(--theme-ui-colors-accent)'
     },
-    h3: {
-      variant: 'text.heading',
-      fontSize: 4
+    fonts: {
+      body: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
+      heading:
+        'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
+      monospace: 'Menlo, monospace'
     },
-    h4: {
-      variant: 'text.heading',
-      fontSize: 3
+    fontSizes: [12, 14, 16, 20, 24, 32, 48, 64, 72],
+    fontWeights: {
+      body: 400,
+      heading: 400,
+      display: 600
     },
-    h5: {
-      variant: 'text.heading',
-      fontSize: 2
+    lineHeights: {
+      body: 1.5,
+      heading: 1.25
     },
-    h6: {
-      variant: 'text.heading',
-      fontSize: 1
-    },
-    a: {
-      color: 'primary',
-      '&:hover': {
-        color: 'secondary'
+    forms: {
+      label: {
+        fontSize: 1,
+        paddingBottom: 2,
+        fontWeight: 600
+      },
+      select: {
+        boxSizing: 'border-box',
+        margin: 0,
+        minWidth: 0,
+        display: 'block',
+        width: '100%',
+        padding: '5px',
+        appearance: 'none',
+        fontSize: 'inherit',
+        lineHeight: 'inherit',
+        border: '1px solid',
+        borderRadius: '4px',
+        color: 'inherit',
+        backgroundColor: 'var(--theme-ui-colors-background)'
       }
     },
-    pre: (theme) => ({
-      fontFamily: scaleGet(theme.fonts, 'monospace'),
-      fontSize: 1,
-      p: 3,
-      color: 'text',
-      bg: 'muted',
-      overflow: 'auto',
-      code: {
-        color: 'inherit'
+    listItems: {
+      active: {
+        outline: '2px solid var(--theme-ui-colors-muted)',
+        outlineOffset: -1
       }
-    }),
-    code: (theme) => ({
-      fontFamily: scaleGet(theme.fonts, 'monospace'),
-      fontSize: 1
-    }),
-    inlineCode: (theme) => ({
-      fontFamily: scaleGet(theme.fonts, 'monospace'),
-      color: 'secondary',
-      bg: 'muted'
-    }),
-    table: {
-      width: '100%',
-      my: 4,
-      borderCollapse: 'separate',
-      borderSpacing: 0,
-      'th,td': (theme) => ({
-        textAlign: 'left',
-        py: '4px',
-        pr: '4px',
-        pl: 0,
-        borderColor: scaleGet(theme.colors, 'muted'),
-        borderBottomStyle: 'solid'
+    },
+    text: {
+      heading: (theme) => ({
+        fontFamily: scaleGet(theme.fonts, 'heading'),
+        fontWeight: scaleGet(theme.fontWeights, 'heading'),
+        lineHeight: scaleGet(theme.lineHeights, 'heading')
+      }),
+      display: () => ({
+        variant: 'heading',
+        fontSize: [5, 6],
+        fontWeight: 'display',
+        letterSpacing: '-0.03em',
+        mt: 3
+      }),
+      section: (theme) => ({
+        textTransform: 'uppercase',
+        fontWeight: 700,
+        fontSize: 0,
+        color: 'grey',
+        letterSpacing: 0.95
       })
     },
-    th: {
-      verticalAlign: 'bottom',
-      borderBottomWidth: '2px'
+    images: {
+      selectable: {
+        padding: '1.5px',
+        borderRadius: 3
+      }
     },
-    td: {
-      verticalAlign: 'top',
-      borderBottomWidth: '1px'
+    buttons: {
+      primary: (theme) => ({
+        ...controlHover,
+        fontSize: 1,
+        padding: 3,
+        paddingLeft: 4,
+        paddingRight: 4,
+        color: scaleGet(theme.colors, 'primaryContrast'),
+        backgroundColor: scaleGet(theme.fonts, 'primary'),
+        borderRadius: scaleGet(theme.radii, 'control'),
+        '&:disabled': {
+          bg: scaleGet(theme.colors, 'muted')
+        }
+      }),
+      icon: {
+        ...controlHover
+      },
+      secondary: (theme) => ({
+        ...controlHover,
+        color: scaleGet(theme.colors, 'background'),
+        bg: scaleGet(theme.colors, 'secondary')
+      }),
+      primaryTransparent: (theme) => ({
+        ...controlHover,
+        color: scaleGet(theme.fonts, 'body'),
+        backgroundColor: scaleGet(theme.colors, 'transparent')
+      })
     },
-    hr: (theme) => ({
-      border: 0,
-      borderBottom: '1px solid',
-      borderColor: scaleGet(theme.colors, 'muted')
-    })
-  }
-};
+    styles: {
+      Container: {
+        p: 3,
+        maxWidth: 1024
+      },
+      root: (theme) => ({
+        fontFamily: scaleGet(theme.fonts, 'body'),
+        lineHeight: scaleGet(theme.lineHeights, 'body'),
+        fontWeight: scaleGet(theme.fontWeights, 'body')
+      }),
+      h1: {
+        variant: 'text.display'
+      },
+      h2: {
+        variant: 'text.heading',
+        fontSize: 5
+      },
+      h3: {
+        variant: 'text.heading',
+        fontSize: 4
+      },
+      h4: {
+        variant: 'text.heading',
+        fontSize: 3
+      },
+      h5: {
+        variant: 'text.heading',
+        fontSize: 2
+      },
+      h6: {
+        variant: 'text.heading',
+        fontSize: 1
+      },
+      a: {
+        color: 'primary',
+        '&:hover': {
+          color: 'secondary'
+        }
+      },
+      pre: (theme) => ({
+        fontFamily: scaleGet(theme.fonts, 'monospace'),
+        fontSize: 1,
+        p: 3,
+        color: 'text',
+        bg: 'muted',
+        overflow: 'auto',
+        code: {
+          color: 'inherit'
+        }
+      }),
+      code: (theme) => ({
+        fontFamily: scaleGet(theme.fonts, 'monospace'),
+        fontSize: 1
+      }),
+      inlineCode: (theme) => ({
+        fontFamily: scaleGet(theme.fonts, 'monospace'),
+        color: 'secondary',
+        bg: 'muted'
+      }),
+      table: {
+        width: '100%',
+        my: 4,
+        borderCollapse: 'separate',
+        borderSpacing: 0,
+        'th,td': (theme) => ({
+          textAlign: 'left',
+          py: '4px',
+          pr: '4px',
+          pl: 0,
+          borderColor: scaleGet(theme.colors, 'muted'),
+          borderBottomStyle: 'solid'
+        })
+      },
+      th: {
+        verticalAlign: 'bottom',
+        borderBottomWidth: '2px'
+      },
+      td: {
+        verticalAlign: 'top',
+        borderBottomWidth: '1px'
+      },
+      hr: (theme) => ({
+        border: 0,
+        borderBottom: '1px solid',
+        borderColor: scaleGet(theme.colors, 'muted')
+      })
+    }
+  };

--- a/src/test/result.ts
+++ b/src/test/result.ts
@@ -3,7 +3,11 @@ import { assert } from '../common/util/assert';
 import { Result } from '../common/util/error';
 
 export function requireSuccess<T>(x: Result<T>) {
-  assert(x.status === 'ok', 'Expected operation to succeed. Got result:', x);
+  assert(
+    x.status === 'ok',
+    'Expected operation to fail. Got error:',
+    JSON.stringify((x as any).error)
+  );
 
   return x.value;
 }


### PR DESCRIPTION
(blocked on #64)

This PR adds support for deleting assets and database records from the archive.

We also add guards against a deletion casusing the schema to move into an invalid state. Currently the logic is as follows:

- If deleting a group of records will lead to a situation where another record has a required property that will be made blank as a result of removing the deleted records, deny the delete
- If a deleted record is referenced by either a non-required property or a multiple-occurance property that references other records that are not being deleted, then remove the reference and allow the record to be deleted.
- Otherwise delete the record.

When an asset is deleted, its media files are removed from disk.

## Usage

![screen](https://user-images.githubusercontent.com/361391/169246455-0f21b51b-e4de-40ac-b93f-7eb240bf7b58.gif)

## Notes

I'm not completely happy with this – it feels to me a bit like we're re-inventing the wheel a bit here by doing referential integrity checks in application code. Sqlite already does this very well and it's obviously very important that this works as expected.

The reason we don't lean on the database do this is it's generally difficult to reconcile using sqlite directly for this kind of thing with keeping the schema editable (foreign key references are currently stored in json fields, for example, rather than in a native database column). It may be worth considering reworking the way that metadata and assets are persisted – making the database schema reflect the archive collection schema rather than layering database-like behaviour on top of a json store.

As noted in #62 and #42, it will probably make sense to revisit the persistence layer and think through how it should work once it's getting some real-world use.