### PR TITLE
Adds support for managing property visibility and access control

### DIFF
--- a/src/app/asset/__tests__/asset.spec.ts
+++ b/src/app/asset/__tests__/asset.spec.ts
@@ -1,4 +1,5 @@
 import {
+  AccessControl,
   defaultSchemaProperty,
   SchemaProperty,
   SchemaPropertyType
@@ -55,6 +56,7 @@ describe(AssetService, () => {
         fixture.archive,
         fixture.rootCollection.id,
         {
+          accessControl: AccessControl.RESTRICTED,
           metadata: {
             requiredProperty: ['1'],
             optionalProperty: ['2'],
@@ -135,6 +137,7 @@ describe(AssetService, () => {
       fixture.archive,
       fixture.rootCollection.id,
       {
+        accessControl: AccessControl.RESTRICTED,
         metadata: {}
       }
     );
@@ -155,6 +158,7 @@ describe(AssetService, () => {
         fixture.archive,
         fixture.rootCollection.id,
         {
+          accessControl: AccessControl.RESTRICTED,
           metadata: {
             requiredProperty: ['1']
           }
@@ -241,6 +245,7 @@ describe(AssetService, () => {
 
         const referencedAsset = requireSuccess(
           await fixture.service.createAsset(fixture.archive, db.id, {
+            accessControl: AccessControl.RESTRICTED,
             metadata: { title: ['Value'] }
           })
         );
@@ -338,6 +343,7 @@ describe(AssetService, () => {
 
       const targetRecord = requireSuccess(
         await fixture.service.createAsset(fixture.archive, targetDb.id, {
+          accessControl: AccessControl.RESTRICTED,
           metadata: {}
         })
       );
@@ -345,7 +351,10 @@ describe(AssetService, () => {
         await fixture.service.createAsset(
           fixture.archive,
           fixture.rootCollection.id,
-          { metadata: { [dbProperty.id]: [targetRecord.id] } }
+          {
+            accessControl: AccessControl.RESTRICTED,
+            metadata: { [dbProperty.id]: [targetRecord.id] }
+          }
         )
       );
 
@@ -380,6 +389,7 @@ describe(AssetService, () => {
 
       const targetRecord = requireSuccess(
         await fixture.service.createAsset(fixture.archive, targetDb.id, {
+          accessControl: AccessControl.RESTRICTED,
           metadata: {}
         })
       );
@@ -388,7 +398,10 @@ describe(AssetService, () => {
         await fixture.service.createAsset(
           fixture.archive,
           fixture.rootCollection.id,
-          { metadata: { [dbProperty.id]: [targetRecord.id] } }
+          {
+            accessControl: AccessControl.RESTRICTED,
+            metadata: { [dbProperty.id]: [targetRecord.id] }
+          }
         )
       );
 
@@ -423,12 +436,14 @@ describe(AssetService, () => {
 
       const targetRecord = requireSuccess(
         await fixture.service.createAsset(fixture.archive, targetDb.id, {
+          accessControl: AccessControl.RESTRICTED,
           metadata: {}
         })
       );
 
       const anotherRecord = requireSuccess(
         await fixture.service.createAsset(fixture.archive, targetDb.id, {
+          accessControl: AccessControl.RESTRICTED,
           metadata: {}
         })
       );
@@ -437,7 +452,10 @@ describe(AssetService, () => {
         await fixture.service.createAsset(
           fixture.archive,
           fixture.rootCollection.id,
-          { metadata: { [dbProperty.id]: [targetRecord.id, anotherRecord.id] } }
+          {
+            accessControl: AccessControl.RESTRICTED,
+            metadata: { [dbProperty.id]: [targetRecord.id, anotherRecord.id] }
+          }
         )
       );
 
@@ -473,11 +491,13 @@ describe(AssetService, () => {
       const targetRecords = [
         requireSuccess(
           await fixture.service.createAsset(fixture.archive, targetDb.id, {
+            accessControl: AccessControl.RESTRICTED,
             metadata: {}
           })
         ),
         requireSuccess(
           await fixture.service.createAsset(fixture.archive, targetDb.id, {
+            accessControl: AccessControl.RESTRICTED,
             metadata: {}
           })
         )
@@ -490,6 +510,7 @@ describe(AssetService, () => {
           fixture.archive,
           fixture.rootCollection.id,
           {
+            accessControl: AccessControl.RESTRICTED,
             metadata: {
               [dbProperty.id]: targedRecordIds
             }

--- a/src/app/asset/__tests__/asset.spec.ts
+++ b/src/app/asset/__tests__/asset.spec.ts
@@ -1,8 +1,8 @@
 import {
+  defaultSchemaProperty,
   SchemaProperty,
   SchemaPropertyType
 } from '../../../common/asset.interfaces';
-import { ok } from '../../../common/util/error';
 import { collectEvents } from '../../../test/event';
 import { requireFailure, requireSuccess } from '../../../test/result';
 import { getTempfiles, getTempPackage } from '../../../test/tempfile';
@@ -17,6 +17,7 @@ import {
 
 const SCHEMA: SchemaProperty[] = [
   {
+    ...defaultSchemaProperty(),
     id: 'optionalProperty',
     label: 'Optional Property',
     type: SchemaPropertyType.FREE_TEXT,
@@ -24,6 +25,7 @@ const SCHEMA: SchemaProperty[] = [
     required: false
   },
   {
+    ...defaultSchemaProperty(),
     id: 'requiredProperty',
     label: 'Some Property',
     type: SchemaPropertyType.FREE_TEXT,
@@ -31,6 +33,7 @@ const SCHEMA: SchemaProperty[] = [
     required: true
   },
   {
+    ...defaultSchemaProperty(),
     id: 'repeatedProperty',
     label: 'Some Property',
     type: SchemaPropertyType.FREE_TEXT,
@@ -177,6 +180,7 @@ describe(AssetService, () => {
         const fixture = await setup();
         const [property] = await fixture.givenTheSchema([
           {
+            ...defaultSchemaProperty(),
             type: SchemaPropertyType.FREE_TEXT,
             id: 'dbRecord',
             label: 'Label',
@@ -199,6 +203,7 @@ describe(AssetService, () => {
         const fixture = await setup();
         const [property] = await fixture.givenTheSchema([
           {
+            ...defaultSchemaProperty(),
             type: SchemaPropertyType.FREE_TEXT,
             id: 'dbRecord',
             label: 'Label',
@@ -224,6 +229,7 @@ describe(AssetService, () => {
         const db = await fixture.givenALabelRecordDatabase();
         const [property] = await fixture.givenTheSchema([
           {
+            ...defaultSchemaProperty(),
             type: SchemaPropertyType.CONTROLLED_DATABASE,
             databaseId: db.id,
             id: 'dbRecord',
@@ -259,6 +265,7 @@ describe(AssetService, () => {
         const db = await fixture.givenALabelRecordDatabase();
         const [property] = await fixture.givenTheSchema([
           {
+            ...defaultSchemaProperty(),
             type: SchemaPropertyType.CONTROLLED_DATABASE,
             databaseId: db.id,
             id: 'dbRecord',
@@ -288,6 +295,7 @@ describe(AssetService, () => {
         const db = await fixture.givenALabelRecordDatabase();
         const [property] = await fixture.givenTheSchema([
           {
+            ...defaultSchemaProperty(),
             type: SchemaPropertyType.CONTROLLED_DATABASE,
             databaseId: db.id,
             id: 'dbRecord',
@@ -539,6 +547,7 @@ async function setup() {
         title: 'Some Database',
         schema: [
           {
+            ...defaultSchemaProperty(),
             id: 'title',
             type: SchemaPropertyType.FREE_TEXT,
             label: 'Title',

--- a/src/app/asset/__tests__/collection.spec.ts
+++ b/src/app/asset/__tests__/collection.spec.ts
@@ -1,4 +1,7 @@
-import { SchemaPropertyType } from '../../../common/asset.interfaces';
+import {
+  defaultSchemaProperty,
+  SchemaPropertyType
+} from '../../../common/asset.interfaces';
 import { UnwrapPromise } from '../../../common/util/types';
 import { requireSuccess } from '../../../test/result';
 import { getTempfiles, getTempPackage } from '../../../test/tempfile';
@@ -21,6 +24,7 @@ describe(CollectionService, () => {
 
     await fixture.service.updateCollectionSchema(fixture.archive, root.id, [
       {
+        ...defaultSchemaProperty(),
         id: 'dogtype',
         label: 'Dog Type',
         required: true,
@@ -80,6 +84,7 @@ describe(CollectionService, () => {
     requireSuccess(
       await fixture.service.updateCollectionSchema(fixture.archive, root.id, [
         {
+          ...defaultSchemaProperty(),
           id: 'dogtype',
           label: 'Dog Type',
           required: false,
@@ -100,6 +105,7 @@ describe(CollectionService, () => {
       root.id,
       [
         {
+          ...defaultSchemaProperty(),
           id: 'dogtype',
           label: 'Dog Type',
           required: true,
@@ -121,6 +127,7 @@ describe(CollectionService, () => {
       root.id,
       [
         {
+          ...defaultSchemaProperty(),
           id: 'dogtype',
           label: 'Dog Type',
           required: true,
@@ -143,6 +150,7 @@ describe(CollectionService, () => {
           title: 'Some Database',
           schema: [
             {
+              ...defaultSchemaProperty(),
               id: 'title',
               label: 'Title',
               type: SchemaPropertyType.FREE_TEXT,
@@ -158,6 +166,7 @@ describe(CollectionService, () => {
         fixture.assetCollection.id,
         [
           {
+            ...defaultSchemaProperty(),
             id: 'dbRef',
             label: 'Database Reference',
             type: SchemaPropertyType.CONTROLLED_DATABASE,

--- a/src/app/asset/__tests__/collection.spec.ts
+++ b/src/app/asset/__tests__/collection.spec.ts
@@ -1,4 +1,5 @@
 import {
+  AccessControl,
   defaultSchemaProperty,
   SchemaPropertyType
 } from '../../../common/asset.interfaces';
@@ -96,6 +97,7 @@ describe(CollectionService, () => {
 
     const testAsset = requireSuccess(
       await fixture.assets.createAsset(fixture.archive, root.id, {
+        accessControl: AccessControl.RESTRICTED,
         metadata: {}
       })
     );
@@ -186,6 +188,7 @@ describe(CollectionService, () => {
 
       const dbRecord = requireSuccess(
         await fixture.assets.createAsset(fixture.archive, db.id, {
+          accessControl: AccessControl.RESTRICTED,
           metadata: {
             title: ['My Database Record']
           }
@@ -196,6 +199,7 @@ describe(CollectionService, () => {
         fixture.archive,
         fixture.assetCollection.id,
         {
+          accessControl: AccessControl.RESTRICTED,
           metadata: {
             dbRef: [dbRecord.id]
           }
@@ -213,6 +217,7 @@ describe(CollectionService, () => {
         fixture.archive,
         fixture.assetCollection.id,
         {
+          accessControl: AccessControl.RESTRICTED,
           metadata: {
             dbRef: ['this is not a valid id']
           }

--- a/src/app/asset/asset.entity.ts
+++ b/src/app/asset/asset.entity.ts
@@ -8,7 +8,10 @@ import {
   Property
 } from '@mikro-orm/core';
 import { randomUUID } from 'crypto';
-import { SchemaPropertyType } from '../../common/asset.interfaces';
+import {
+  AccessControl,
+  SchemaPropertyType
+} from '../../common/asset.interfaces';
 import { Dict } from '../../common/util/types';
 import { MediaFile } from '../media/media-file.entity';
 import { SchemaPropertyValue } from './metadata.entity';
@@ -40,6 +43,12 @@ export class AssetEntity {
    */
   @Property({ type: 'json', nullable: false })
   metadata: Dict<unknown[]> = {};
+
+  /**
+   * Key-value metadata properties. Keys are the id of schema property
+   */
+  @Property({ type: 'string', nullable: false })
+  accessControl: AccessControl = AccessControl.RESTRICTED;
 }
 
 /**

--- a/src/app/asset/asset.init.ts
+++ b/src/app/asset/asset.init.ts
@@ -56,8 +56,11 @@ export function initAssets(router: ElectronRouter, media: MediaFileService) {
 
   router.bindArchiveRpc(
     UpdateAssetMetadata,
-    (archive, { assetId, payload }) => {
-      return assetService.updateAsset(archive, assetId, { metadata: payload });
+    (archive, { assetId, payload, accessControl }) => {
+      return assetService.updateAsset(archive, assetId, {
+        metadata: payload,
+        accessControl
+      });
     }
   );
 

--- a/src/app/asset/metadata.entity.ts
+++ b/src/app/asset/metadata.entity.ts
@@ -2,6 +2,7 @@ import { Embeddable, Property } from '@mikro-orm/core';
 import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import {
+  AccessControl,
   AssetMetadataItem,
   ControlledDatabaseSchemaProperty,
   ScalarSchemaProperty,
@@ -49,6 +50,9 @@ export abstract class SchemaPropertyValue {
   constructor() {
     if (typeof this.repeated === 'undefined') {
       this.repeated = false;
+    }
+    if (typeof this.visible === 'undefined') {
+      this.visible = true;
     }
   }
 
@@ -280,6 +284,7 @@ export class ControlledDatabaseSchemaPropertyValue
       context.archive,
       this.databaseId,
       {
+        accessControl: AccessControl.RESTRICTED,
         metadata
       }
     );

--- a/src/app/asset/metadata.entity.ts
+++ b/src/app/asset/metadata.entity.ts
@@ -83,6 +83,12 @@ export abstract class SchemaPropertyValue {
   repeated!: boolean;
 
   /**
+   * True if the property is visible to public.
+   */
+  @Property({ type: 'boolean', default: true })
+  visible!: boolean;
+
+  /**
    * Override to define how raw values in the database are converted into `AssetMetadataItem` values for presentation
    * in the UI
    */

--- a/src/app/asset/test-utils.ts
+++ b/src/app/asset/test-utils.ts
@@ -4,6 +4,7 @@ import {
   Asset,
   AssetMetadata,
   AssetMetadataItem,
+  defaultSchemaProperty,
   SchemaProperty,
   SchemaPropertyType
 } from '../../common/asset.interfaces';
@@ -22,10 +23,9 @@ export const someSchemaProperty = (
   props: Partial<SchemaProperty> = {}
 ): SchemaProperty => {
   const base = {
+    ...defaultSchemaProperty(),
     id: faker.datatype.uuid(),
-    label: faker.word.noun(),
-    required: false,
-    repeated: false
+    label: faker.word.noun()
   };
 
   if (!props.type || props.type === SchemaPropertyType.FREE_TEXT) {

--- a/src/app/asset/test-utils.ts
+++ b/src/app/asset/test-utils.ts
@@ -1,6 +1,7 @@
 import faker from '@faker-js/faker';
 import { mapValues, times } from 'lodash';
 import {
+  AccessControl,
   Asset,
   AssetMetadata,
   AssetMetadataItem,
@@ -16,6 +17,7 @@ export const someAsset = (props: Partial<Asset> = {}): Asset => ({
   media: [],
   metadata: {},
   title: faker.word.noun(),
+  accessControl: AccessControl.RESTRICTED,
   ...props
 });
 

--- a/src/app/ingest/__tests__/asset-import.spec.ts
+++ b/src/app/ingest/__tests__/asset-import.spec.ts
@@ -1,6 +1,7 @@
 import { compact, mapValues } from 'lodash';
 import path from 'path';
 import {
+  AccessControl,
   defaultSchemaProperty,
   SchemaProperty,
   SchemaPropertyType
@@ -344,10 +345,14 @@ describe('AssetImportOperation', () => {
 
     const sessionsEmittingEdit = fixture.editEvents((e) => e.session);
     for (const asset of assets.items) {
-      await session.updateImportedAsset(asset.id, {
-        ...mapValues(asset.metadata, (x) => x.rawValue),
-        extra: ['Some Value']
-      });
+      await session.updateImportedAsset(
+        asset.id,
+        {
+          ...mapValues(asset.metadata, (x) => x.rawValue),
+          extra: ['Some Value']
+        },
+        AccessControl.RESTRICTED
+      );
     }
 
     assets = await fixture.importService.listSessionAssets(

--- a/src/app/ingest/__tests__/asset-import.spec.ts
+++ b/src/app/ingest/__tests__/asset-import.spec.ts
@@ -1,6 +1,7 @@
 import { compact, mapValues } from 'lodash';
 import path from 'path';
 import {
+  defaultSchemaProperty,
   SchemaProperty,
   SchemaPropertyType
 } from '../../../common/asset.interfaces';
@@ -59,6 +60,7 @@ describe('AssetImportOperation', () => {
     const fixture = await setup();
     await fixture.givenACollectionMetadataSchema([
       {
+        ...defaultSchemaProperty(),
         type: SchemaPropertyType.FREE_TEXT,
         id: 'missingProperty',
         repeated: false,
@@ -237,6 +239,7 @@ describe('AssetImportOperation', () => {
         title: 'Other collection',
         schema: [
           {
+            ...defaultSchemaProperty(),
             label: 'property',
             id: 'p',
             type: SchemaPropertyType.FREE_TEXT,
@@ -272,6 +275,7 @@ describe('AssetImportOperation', () => {
     const fixture = await setup();
     await fixture.givenACollectionMetadataSchema([
       {
+        ...defaultSchemaProperty(),
         label: 'property',
         id: 'p',
         repeated: false,
@@ -313,6 +317,7 @@ describe('AssetImportOperation', () => {
     const fixture = await setup();
     await fixture.givenACollectionMetadataSchema([
       {
+        ...defaultSchemaProperty(),
         label: 'property',
         id: 'p',
         type: SchemaPropertyType.FREE_TEXT,
@@ -320,6 +325,7 @@ describe('AssetImportOperation', () => {
         repeated: true
       },
       {
+        ...defaultSchemaProperty(),
         label: 'extraProperty',
         id: 'extra',
         type: SchemaPropertyType.FREE_TEXT,
@@ -358,6 +364,7 @@ describe('AssetImportOperation', () => {
     const fixture = await setup();
     await fixture.givenACollectionMetadataSchema([
       {
+        ...defaultSchemaProperty(),
         label: 'property',
         id: 'p',
         type: SchemaPropertyType.FREE_TEXT,
@@ -365,6 +372,7 @@ describe('AssetImportOperation', () => {
         repeated: true
       },
       {
+        ...defaultSchemaProperty(),
         label: 'extraProperty',
         id: 'extra',
         type: SchemaPropertyType.FREE_TEXT,
@@ -382,6 +390,7 @@ describe('AssetImportOperation', () => {
       fixture.rootCollection.id,
       [
         {
+          ...defaultSchemaProperty(),
           label: 'property',
           id: 'p',
           type: SchemaPropertyType.FREE_TEXT,
@@ -389,6 +398,7 @@ describe('AssetImportOperation', () => {
           repeated: true
         },
         {
+          ...defaultSchemaProperty(),
           label: 'extraProperty',
           id: 'extra',
           type: SchemaPropertyType.FREE_TEXT,
@@ -409,6 +419,7 @@ describe('AssetImportOperation', () => {
       fixture.rootCollection.id,
       [
         {
+          ...defaultSchemaProperty(),
           label: 'property',
           id: 'property',
           type: SchemaPropertyType.FREE_TEXT,
@@ -444,6 +455,7 @@ describe('AssetImportOperation', () => {
       fixture.rootCollection.id,
       [
         {
+          ...defaultSchemaProperty(),
           label: 'property',
           id: 'property',
           type: SchemaPropertyType.FREE_TEXT,
@@ -474,6 +486,7 @@ describe('AssetImportOperation', () => {
       fixture.rootCollection.id,
       [
         {
+          ...defaultSchemaProperty(),
           label: 'Title',
           id: 'title',
           type: SchemaPropertyType.FREE_TEXT,
@@ -481,6 +494,7 @@ describe('AssetImportOperation', () => {
           repeated: true
         },
         {
+          ...defaultSchemaProperty(),
           label: 'Style',
           id: 'style',
           type: SchemaPropertyType.FREE_TEXT,
@@ -624,6 +638,7 @@ const BASIC_EXAMPLE = path.join(
 
 const BASIC_EXAMPLE_SCHEMA: SchemaProperty[] = [
   {
+    ...defaultSchemaProperty(),
     type: SchemaPropertyType.FREE_TEXT,
     id: 'internalPropertyId',
     label: 'property',

--- a/src/app/ingest/asset-import.entity.ts
+++ b/src/app/ingest/asset-import.entity.ts
@@ -8,6 +8,7 @@ import {
   Entity
 } from '@mikro-orm/core';
 import { randomUUID } from 'crypto';
+import { AccessControl } from '../../common/asset.interfaces';
 
 import { IngestError, IngestPhase } from '../../common/ingest.interfaces';
 import { Dict } from '../../common/util/types';
@@ -53,6 +54,10 @@ export class AssetImportEntity {
   /** Unique and deterministic string representing the source of the ingested asset */
   @Property({ type: 'string', nullable: false })
   path!: string;
+
+  /** Unique and deterministic string representing the source of the ingested asset */
+  @Property({ type: 'string', nullable: true })
+  accessControl!: AccessControl;
 
   /** Import session that this asset is managed by */
   @ManyToOne(() => ImportSessionEntity, {

--- a/src/app/ingest/asset-ingest.service.ts
+++ b/src/app/ingest/asset-ingest.service.ts
@@ -149,6 +149,7 @@ export class AssetIngestService extends EventEmitter<Events> {
         res.items.map(async (entity) => ({
           id: entity.id,
           title: entity.id,
+          accessControl: entity.accessControl,
           metadata: mapValues(entity.metadata, (rawValue) => ({
             rawValue,
             presentationValue: rawValue.map((x) => ({
@@ -194,6 +195,7 @@ export class AssetIngestService extends EventEmitter<Events> {
           session.targetCollectionId,
           {
             metadata: assetImport.metadata,
+            accessControl: assetImport.accessControl,
             media: compact(
               assetImport.files.getItems().map((item) => item.media)
             )

--- a/src/app/ingest/ingest.init.ts
+++ b/src/app/ingest/ingest.init.ts
@@ -153,13 +153,13 @@ export async function initIngest(
 
   router.bindArchiveRpc(
     UpdateIngestedMetadata,
-    async (archive, { assetId, sessionId, metadata }) => {
+    async (archive, { assetId, sessionId, metadata, accessControl }) => {
       const session = assetIngest.getSession(archive, sessionId);
       if (!session) {
         return error(FetchError.DOES_NOT_EXIST);
       }
 
-      return session.updateImportedAsset(assetId, metadata);
+      return session.updateImportedAsset(assetId, metadata, accessControl);
     }
   );
 

--- a/src/app/migrations/.snapshot-migrations.sqlite.json
+++ b/src/app/migrations/.snapshot-migrations.sqlite.json
@@ -190,6 +190,15 @@
           "nullable": false,
           "mappedType": "text"
         },
+        "access_control": {
+          "name": "access_control",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
         "session_id": {
           "name": "session_id",
           "type": "text",
@@ -300,6 +309,15 @@
           "primary": false,
           "nullable": false,
           "mappedType": "json"
+        },
+        "access_control": {
+          "name": "access_control",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
         }
       },
       "name": "asset",

--- a/src/app/migrations/Migration20220608153338.ts
+++ b/src/app/migrations/Migration20220608153338.ts
@@ -1,0 +1,31 @@
+import { Migration } from '@mikro-orm/migrations';
+import { required } from '../../common/util/assert';
+
+export class Migration20220608153338 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'alter table `asset_import` add column `access_control` text null;'
+    );
+
+    this.addSql(
+      "alter table `asset` add column `access_control` text not null default 'RESTRICTED';"
+    );
+
+    const t = required(this.ctx, 'Expected a transaction');
+
+    // Define the repeaeted property on all schemas
+    const collections = await t.table('asset_collection').select();
+
+    for (const c of collections) {
+      const schema = JSON.parse(c.schema);
+      for (const property of schema) {
+        property.visible = true;
+      }
+
+      await t
+        .table('asset_collection')
+        .where({ id: c.id })
+        .update('schema', JSON.stringify(schema));
+    }
+  }
+}

--- a/src/common/asset.interfaces.ts
+++ b/src/common/asset.interfaces.ts
@@ -77,6 +77,9 @@ const BaseSchemaProperty = z.object({
   /** Does the property support multiple occurances? */
   repeated: z.boolean(),
 
+  /** Is the the property visible to the public? */
+  visible: z.boolean(),
+
   /** Underlying type of the property? */
   type: z.nativeEnum(SchemaPropertyType)
 });
@@ -154,11 +157,12 @@ export type SchemaProperty = z.TypeOf<typeof SchemaProperty>;
  * @param i Index of the property in the schema – used to generate a unique label.
  * @returns A new schema property with default values.
  */
-export const defaultSchemaProperty = (i: number): SchemaProperty => ({
+export const defaultSchemaProperty = (i?: number): SchemaProperty => ({
   id: v4(),
-  label: `Property ${i}`,
+  label: `Property ${i ?? ''}`,
   required: false,
   repeated: false,
+  visible: true,
   type: SchemaPropertyType.FREE_TEXT
 });
 

--- a/src/common/asset.interfaces.ts
+++ b/src/common/asset.interfaces.ts
@@ -1,3 +1,4 @@
+import { startCase } from 'lodash';
 import { v4 } from 'uuid';
 import { z } from 'zod';
 import { ErrorType, RequestType, RpcInterface } from './ipc.interfaces';
@@ -35,6 +36,23 @@ export interface AssetMetadataItem<T = unknown> {
 }
 
 /**
+ * Enum value for asset access rights.
+ */
+export enum AccessControl {
+  /** The media files and metadata are visible to the public and published */
+  PUBLIC = 'PUBLIC',
+
+  /** The metadata only is visible to the public */
+  METADATA_ONLY = 'METADATA_ONLY',
+
+  /** Metadata and media files are not visible to the public */
+  RESTRICTED = 'RESTRICTED'
+}
+
+export const getAccessControlLabel = (ac: AccessControl) =>
+  startCase(ac.toLowerCase().replace(/_/g, ' '));
+
+/**
  * Represent a single asset.
  */
 export const Asset = z.object({
@@ -48,7 +66,10 @@ export const Asset = z.object({
   metadata: z.record(AssetMetadataItem),
 
   /** All media files associated with the asset */
-  media: z.array(Media)
+  media: z.array(Media),
+
+  /** Information about access rights */
+  accessControl: z.nativeEnum(AccessControl)
 });
 export type Asset = z.TypeOf<typeof Asset>;
 export type AssetMetadata = Asset['metadata'];
@@ -295,7 +316,8 @@ export const CreateAsset = RpcInterface({
   id: 'assets/create',
   request: z.object({
     collection: z.string(),
-    metadata: z.record(z.array(z.unknown()))
+    metadata: z.record(z.array(z.unknown())),
+    accessControl: z.nativeEnum(AccessControl)
   }),
   response: Asset,
   error: z.nativeEnum(FetchError)
@@ -335,7 +357,8 @@ export const UpdateAssetMetadata = RpcInterface({
   id: 'assets/update',
   request: z.object({
     assetId: z.string(),
-    payload: z.record(z.array(z.unknown()))
+    payload: z.record(z.array(z.unknown())).optional(),
+    accessControl: z.nativeEnum(AccessControl).optional()
   }),
   response: z.object({}),
   error: z.nativeEnum(FetchError).or(SingleValidationError)

--- a/src/common/ingest.interfaces.ts
+++ b/src/common/ingest.interfaces.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { RequestType, ResponseType, RpcInterface } from './ipc.interfaces';
-import { Asset, SingleValidationError } from './asset.interfaces';
+import {
+  AccessControl,
+  Asset,
+  SingleValidationError
+} from './asset.interfaces';
 import { FetchError, Result } from './util/error';
 import { ResourceList } from './resource';
 
@@ -130,7 +134,8 @@ export const UpdateIngestedMetadata = RpcInterface({
   request: z.object({
     assetId: z.string(),
     sessionId: z.string(),
-    metadata: z.record(z.array(z.unknown()))
+    metadata: z.record(z.array(z.unknown())),
+    accessControl: z.nativeEnum(AccessControl)
   }),
   response: z.object({})
 });

--- a/src/frontend/screens/asset-detail.sceen.tsx
+++ b/src/frontend/screens/asset-detail.sceen.tsx
@@ -1,26 +1,19 @@
 /** @jsxImportSource theme-ui */
 
-import { mapValues } from 'lodash';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Button, Flex, Text } from 'theme-ui';
-import {
-  AssetMetadata,
-  CreateAsset,
-  GetAsset,
-  GetCollection
-} from '../../common/asset.interfaces';
+import { GetAsset, GetCollection } from '../../common/asset.interfaces';
 import { required } from '../../common/util/assert';
-import { useGet, useRPC } from '../ipc/ipc.hooks';
+import { useGet } from '../ipc/ipc.hooks';
 import { AssetDetail } from '../ui/components/asset-detail.component';
 import {
-  MetadataInspector,
+  MetadataInspectorData,
   RecordInspector
 } from '../ui/components/inspector.component';
 import { PrimaryDetailLayout } from '../ui/components/page-layouts.component';
 import { useAssets } from '../ui/hooks/asset.hooks';
 import { useErrorDisplay } from '../ui/hooks/error.hooks';
-import { WindowInset, WindowTitle } from '../ui/window';
+import { WindowTitle } from '../ui/window';
 
 export const AssetDetailScreen = () => {
   const [params] = useSearchParams();
@@ -39,7 +32,7 @@ export const AssetDetailScreen = () => {
   const asset = errors.guard(useGet(GetAsset, assetId));
 
   const handleEdit = useCallback(
-    async (edits: AssetMetadata) => {
+    async (edits: MetadataInspectorData) => {
       if (asset) {
         return assetOps.updateMetadata(asset, edits);
       }

--- a/src/frontend/screens/collection.screen.tsx
+++ b/src/frontend/screens/collection.screen.tsx
@@ -30,7 +30,10 @@ import { Gear, Plus } from 'react-bootstrap-icons';
 import { MetadataItemCell } from '../ui/components/grid-cell.component';
 import { useErrorDisplay } from '../ui/hooks/error.hooks';
 import { useModal } from '../ui/hooks/window.hooks';
-import { RecordInspector } from '../ui/components/inspector.component';
+import {
+  MetadataInspectorData,
+  RecordInspector
+} from '../ui/components/inspector.component';
 import { useAssets } from '../ui/hooks/asset.hooks';
 
 /**
@@ -80,7 +83,7 @@ export const CollectionScreen: FC = () => {
   }, [assets, selection]);
 
   const handleCommitEdits = useCallback(
-    async (change: AssetMetadata) => {
+    async (change: MetadataInspectorData) => {
       if (selectedAsset) {
         return assetOps.updateMetadata(selectedAsset, change);
       }

--- a/src/frontend/screens/ingest.screen.tsx
+++ b/src/frontend/screens/ingest.screen.tsx
@@ -36,7 +36,10 @@ import { DataGrid, GridColumn } from '../ui/components/grid.component';
 import { PrimaryDetailLayout } from '../ui/components/page-layouts.component';
 import { SelectionContext } from '../ui/hooks/selection.hooks';
 import { BottomBar } from '../ui/components/page-layouts.component';
-import { RecordInspector } from '../ui/components/inspector.component';
+import {
+  MetadataInspectorData,
+  RecordInspector
+} from '../ui/components/inspector.component';
 import { useErrorDisplay } from '../ui/hooks/error.hooks';
 import { mapValues } from 'lodash';
 
@@ -66,16 +69,17 @@ export const ArchiveIngestScreen: FC = () => {
 
   /** Update the metadata for an imported asset */
   const updateIngestedAsset = useCallback(
-    async (change: AssetMetadata): Promise<undefined> => {
+    async (change: MetadataInspectorData): Promise<undefined> => {
       if (!sessionId || !selectedAsset?.id) {
         return;
       }
 
-      const metadata = { ...selectedAsset.metadata, ...change };
+      const metadata = { ...selectedAsset.metadata, ...change.metadata };
 
       const res = await rpc(UpdateIngestedMetadata, {
         assetId: selectedAsset.id,
         metadata: mapValues(metadata, (md) => md.rawValue),
+        accessControl: change.accessControl ?? selectedAsset.accessControl,
         sessionId
       });
 

--- a/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
+++ b/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
@@ -41,7 +41,7 @@ export const WithMedia: FC<Params> = ({ onUpdate }) => {
   });
 
   const ipc = useIpcFixture((change) => {
-    setMetadata(assetMetadata(change.payload));
+    setMetadata(assetMetadata(change.payload ?? {}));
     onUpdate(change);
   });
 

--- a/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
+++ b/src/frontend/ui/components/__stories__/asset-detail.stories.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../../app/asset/test-utils';
 import {
   CollectionType,
+  defaultSchemaProperty,
   GetCollection,
   SchemaProperty,
   SchemaPropertyType,
@@ -112,6 +113,7 @@ const MEDIA_FILES: Media[] = [
 
 const SCHEMA: SchemaProperty[] = [
   {
+    ...defaultSchemaProperty(),
     id: 'someProperty',
     label: 'Some Property',
     required: true,
@@ -119,6 +121,7 @@ const SCHEMA: SchemaProperty[] = [
     type: SchemaPropertyType.FREE_TEXT
   },
   {
+    ...defaultSchemaProperty(),
     id: 'databaseRef',
     label: 'Database Reference',
     required: false,

--- a/src/frontend/ui/components/__stories__/schema-editor.stories.tsx
+++ b/src/frontend/ui/components/__stories__/schema-editor.stories.tsx
@@ -34,6 +34,7 @@ export const WithProperties = () => {
       id: String(i),
       label: faker.animal.dog(),
       required: faker.datatype.boolean(),
+      visible: faker.datatype.boolean(),
       repeated: false,
       type: SchemaPropertyType.FREE_TEXT
     }))
@@ -55,6 +56,7 @@ export const WithErrors = () => {
       id: String(i),
       label: faker.animal.dog(),
       required: faker.datatype.boolean(),
+      visible: faker.datatype.boolean(),
       repeated: false,
       type: SchemaPropertyType.FREE_TEXT
     }))

--- a/src/frontend/ui/components/schema-editor.component.tsx
+++ b/src/frontend/ui/components/schema-editor.component.tsx
@@ -273,6 +273,23 @@ export const SchemaEditor: FC<SchemaEditorProps> = ({
                 )}
               />
             </Box>
+            <Box>
+              <Switch
+                sx={{
+                  'input:checked ~ &': {
+                    backgroundColor: 'var(--theme-ui-colors-primary)'
+                  }
+                }}
+                label="Visible to Public"
+                checked={item.visible}
+                onChange={changeCallback(
+                  item.id,
+                  (prev, event: ChangeEvent<HTMLInputElement>) => {
+                    prev.visible = event.currentTarget.checked;
+                  }
+                )}
+              />
+            </Box>
           </Flex>
 
           <Box>

--- a/src/frontend/ui/hooks/asset.hooks.ts
+++ b/src/frontend/ui/hooks/asset.hooks.ts
@@ -1,6 +1,7 @@
 import { mapValues } from 'lodash';
 import { useMemo } from 'react';
 import {
+  AccessControl,
   Asset,
   AssetMetadata,
   SingleValidationError,
@@ -20,11 +21,15 @@ export function useAssets(collectionId: string) {
     () => ({
       updateMetadata: async (
         asset: Asset,
-        edits: AssetMetadata
+        edits: { metadata?: AssetMetadata; accessControl?: AccessControl }
       ): Promise<undefined | SingleValidationError> => {
-        const metadata = { ...asset.metadata, ...edits };
+        const metadata = edits.metadata && {
+          ...asset.metadata,
+          ...edits.metadata
+        };
         const res = await rpc(UpdateAssetMetadata, {
           assetId: asset.id,
+          accessControl: edits.accessControl,
           payload: mapValues(metadata, (item) => item.rawValue)
         });
 


### PR DESCRIPTION
This adds support for managing access control to the admin interface. This comes out in 2 places:

* Visibility setting on schema properties – controls whether a property is visible to third parties
* Access control on individual assets – controls whether an asset and its metadata, only the metadata, or neither, are shared with external parties.

Currently, these doesn't affect anything, but the settings are saved in the local archive for use in future.

<img width="801" alt="Screenshot 2022-06-14 at 17 13 54" src="https://user-images.githubusercontent.com/361391/173625692-79f558cb-deb0-44c6-a48a-59c26c616363.png">

<img width="308" alt="Screenshot 2022-06-14 at 17 14 13" src="https://user-images.githubusercontent.com/361391/173625769-80945478-48b1-470b-91a6-52db541e9ef4.png">
 