### PR TITLE
Support for multiple asset collections

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,4 +38,4 @@ jobs:
         run: yarn tsc --noemit
 
       - name: Lint
-        run: yarn eslint . && yarn prettier .
+        run: yarn eslint . && yarn prettier --check src

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "polished": "^4.1.4",
     "react": "^17.0.2",
     "react-bootstrap-icons": "^1.7.2",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^17.0.2",
     "react-dropzone": "^14.2.1",
     "react-reflex": "^4.0.8",

--- a/src/app/asset/__tests__/asset.spec.ts
+++ b/src/app/asset/__tests__/asset.spec.ts
@@ -50,7 +50,7 @@ describe(AssetService, () => {
     const asset = requireSuccess(
       await fixture.service.createAsset(
         fixture.archive,
-        fixture.rootCollection.id,
+        fixture.assetCollection.id,
         {
           metadata: {
             requiredProperty: ['1'],
@@ -72,7 +72,7 @@ describe(AssetService, () => {
     expect(
       await fixture.service.listAssets(
         fixture.archive,
-        fixture.rootCollection.id
+        fixture.assetCollection.id
       )
     ).toEqual(
       expect.objectContaining({
@@ -108,7 +108,7 @@ describe(AssetService, () => {
     expect(
       await fixture.service.listAssets(
         fixture.archive,
-        fixture.rootCollection.id
+        fixture.assetCollection.id
       )
     ).toEqual(
       expect.objectContaining({
@@ -130,7 +130,7 @@ describe(AssetService, () => {
 
     const res = await fixture.service.createAsset(
       fixture.archive,
-      fixture.rootCollection.id,
+      fixture.assetCollection.id,
       {
         metadata: {}
       }
@@ -150,7 +150,7 @@ describe(AssetService, () => {
     const asset = requireSuccess(
       await fixture.service.createAsset(
         fixture.archive,
-        fixture.rootCollection.id,
+        fixture.assetCollection.id,
         {
           metadata: {
             requiredProperty: ['1']
@@ -336,7 +336,7 @@ describe(AssetService, () => {
       const referencingRecord = requireSuccess(
         await fixture.service.createAsset(
           fixture.archive,
-          fixture.rootCollection.id,
+          fixture.assetCollection.id,
           { metadata: { [dbProperty.id]: [targetRecord.id] } }
         )
       );
@@ -379,7 +379,7 @@ describe(AssetService, () => {
       const referencingRecord = requireSuccess(
         await fixture.service.createAsset(
           fixture.archive,
-          fixture.rootCollection.id,
+          fixture.assetCollection.id,
           { metadata: { [dbProperty.id]: [targetRecord.id] } }
         )
       );
@@ -428,7 +428,7 @@ describe(AssetService, () => {
       const referencingRecord = requireSuccess(
         await fixture.service.createAsset(
           fixture.archive,
-          fixture.rootCollection.id,
+          fixture.assetCollection.id,
           { metadata: { [dbProperty.id]: [targetRecord.id, anotherRecord.id] } }
         )
       );
@@ -480,7 +480,7 @@ describe(AssetService, () => {
       requireSuccess(
         await fixture.service.createAsset(
           fixture.archive,
-          fixture.rootCollection.id,
+          fixture.assetCollection.id,
           {
             metadata: {
               [dbProperty.id]: targedRecordIds
@@ -507,7 +507,7 @@ async function setup() {
   const collectionService = new CollectionService();
   const mediaService = new MediaFileService();
   const service = new AssetService(collectionService, mediaService);
-  const rootCollection = await collectionService.getRootAssetCollection(
+  const assetCollection = await collectionService.getRootAssetCollection(
     archive
   );
   const rootDbCollection = await collectionService.getRootDatabaseCollection(
@@ -515,7 +515,7 @@ async function setup() {
   );
   await collectionService.updateCollectionSchema(
     archive,
-    rootCollection.id,
+    assetCollection.id,
     SCHEMA
   );
 
@@ -523,7 +523,7 @@ async function setup() {
     givenTheSchema: async (schema: SchemaProperty[]) => {
       await collectionService.updateCollectionSchema(
         archive,
-        rootCollection.id,
+        assetCollection.id,
         schema
       );
       return schema;
@@ -550,7 +550,7 @@ async function setup() {
     },
     archive,
     collectionService,
-    rootCollection,
+    assetCollection,
     mediaService,
     service
   };

--- a/src/app/asset/__tests__/asset.spec.ts
+++ b/src/app/asset/__tests__/asset.spec.ts
@@ -498,6 +498,74 @@ describe(AssetService, () => {
       ).toHaveProperty('total', 2);
     });
   });
+
+  describe('moving assets', () => {
+    test('assets can be moved between compatible collections', async () => {
+      const fixture = await setup();
+      const otherCollection = await fixture.collectionService.createCollection(
+        fixture.archive,
+        fixture.rootAssetCollection.id,
+        { title: 'Other Collection', schema: [] }
+      );
+      const asset = requireSuccess(
+        await fixture.service.createAsset(
+          fixture.archive,
+          fixture.assetCollection.id,
+          { metadata: { requiredProperty: ['Hello'] } }
+        )
+      );
+
+      requireSuccess(
+        await fixture.service.moveAssets(
+          fixture.archive,
+          [asset.id],
+          otherCollection.id
+        )
+      );
+      const oldCollectionAssets = await fixture.service.listAssets(
+        fixture.archive,
+        fixture.assetCollection.id
+      );
+      const newCollectionAssets = await fixture.service.listAssets(
+        fixture.archive,
+        otherCollection.id
+      );
+
+      expect(oldCollectionAssets.total).toBe(0);
+      expect(newCollectionAssets.total).toBe(1);
+    });
+  });
+
+  test('assets cannot be moved between incompatible collections', async () => {
+    const fixture = await setup();
+
+    const database = await fixture.givenAControlledDatabaseWithSchema([]);
+
+    const asset = requireSuccess(
+      await fixture.service.createAsset(
+        fixture.archive,
+        fixture.assetCollection.id,
+        {
+          metadata: { requiredProperty: ['Hello'] }
+        }
+      )
+    );
+
+    requireFailure(
+      await fixture.service.moveAssets(fixture.archive, [asset.id], database.id)
+    );
+    const oldCollectionAssets = await fixture.service.listAssets(
+      fixture.archive,
+      fixture.assetCollection.id
+    );
+    const newCollectionAssets = await fixture.service.listAssets(
+      fixture.archive,
+      database.id
+    );
+
+    expect(oldCollectionAssets.total).toBe(1);
+    expect(newCollectionAssets.total).toBe(0);
+  });
 });
 
 async function setup() {
@@ -507,7 +575,7 @@ async function setup() {
   const collectionService = new CollectionService();
   const mediaService = new MediaFileService();
   const service = new AssetService(collectionService, mediaService);
-  const assetCollection = await collectionService.getRootAssetCollection(
+  const rootAssetCollection = await collectionService.getRootAssetCollection(
     archive
   );
   const rootDbCollection = await collectionService.getRootDatabaseCollection(
@@ -515,15 +583,21 @@ async function setup() {
   );
   await collectionService.updateCollectionSchema(
     archive,
-    assetCollection.id,
+    rootAssetCollection.id,
     SCHEMA
+  );
+
+  const assetCollection = await collectionService.createCollection(
+    archive,
+    rootAssetCollection.id,
+    { schema: [], title: 'My Collection' }
   );
 
   return {
     givenTheSchema: async (schema: SchemaProperty[]) => {
       await collectionService.updateCollectionSchema(
         archive,
-        assetCollection.id,
+        rootAssetCollection.id,
         schema
       );
       return schema;
@@ -550,6 +624,8 @@ async function setup() {
     },
     archive,
     collectionService,
+    rootAssetCollection,
+    rootDbCollection,
     assetCollection,
     mediaService,
     service

--- a/src/app/asset/asset.entity.ts
+++ b/src/app/asset/asset.entity.ts
@@ -82,37 +82,8 @@ export class AssetCollectionEntity {
   /**
    * Schema associated with this collection
    */
-  @Embedded(() => SchemaPropertyValue, { array: true })
+  @Embedded(() => SchemaPropertyValue, {
+    array: true
+  })
   schema: SchemaPropertyValue[] = [];
-
-  /**
-   * Return the schema property that is used
-   *
-   * This is currently defined as the first free text property in the schema. It may in future change to something more
-   * explicit.
-   *
-   * @returns The scehma property used as the label for the asset, or undefined if no suitable property exists.
-   */
-  getTitleProperty() {
-    return this.schema.find((x) => (x.type = SchemaPropertyType.FREE_TEXT));
-  }
-
-  /**
-   * If this collection can hold 'label records', return the metadata for a label record given a string value to be the
-   * label.
-   *
-   * A 'label record' is a record where the only required property (if any) is its title property. These can be created
-   * easily from a string value.
-   *
-   * @param title The title property for the label record
-   * @returns A Dict of metadata for creating/updating a label record.
-   */
-  getLabelRecordMetadata(title: string) {
-    const titleProperty = this.getTitleProperty();
-    const canBeLabelRecord =
-      !!titleProperty &&
-      this.schema.every((x) => !x.required || x.id === titleProperty.id);
-
-    return canBeLabelRecord ? { [titleProperty.id]: [title] } : undefined;
-  }
 }

--- a/src/app/asset/asset.init.ts
+++ b/src/app/asset/asset.init.ts
@@ -13,7 +13,9 @@ import {
   SearchAsset,
   DeleteAssets,
   AddAssetMedia,
-  RemoveAssetMedia
+  RemoveAssetMedia,
+  MoveAssets,
+  ValidateMoveAssets
 } from '../../common/asset.interfaces';
 import { ChangeEvent } from '../../common/resource';
 import { ok, okIfExists } from '../../common/util/error';
@@ -64,6 +66,24 @@ export function initAssets(router: ElectronRouter, media: MediaFileService) {
   router.bindArchiveRpc(DeleteAssets, (archive, { assetIds }) => {
     return assetService.deleteAssets(archive, assetIds);
   });
+
+  router.bindArchiveRpc(
+    MoveAssets,
+    (archive, { assetIds, targetCollectionId }) => {
+      return assetService.moveAssets(archive, assetIds, targetCollectionId);
+    }
+  );
+
+  router.bindArchiveRpc(
+    ValidateMoveAssets,
+    (archive, { assetIds, targetCollectionId }) => {
+      return assetService.validateMoveAssets(
+        archive,
+        assetIds,
+        targetCollectionId
+      );
+    }
+  );
 
   router.bindArchiveRpc(
     CreateCollection,

--- a/src/app/asset/asset.service.ts
+++ b/src/app/asset/asset.service.ts
@@ -463,7 +463,7 @@ export class AssetService extends EventEmitter<AssetEvents> {
     archive: ArchivePackage,
     assetIds: string[],
     collectionId: string
-  ) {
+  ): Promise<Result<object, FetchError | AggregatedValidationError>> {
     const res = await archive.useDb(async (db) => {
       const validationResult = await this.validateMoveAssets(
         archive,

--- a/src/app/asset/metadata.entity.ts
+++ b/src/app/asset/metadata.entity.ts
@@ -263,7 +263,11 @@ export class ControlledDatabaseSchemaPropertyValue
 
     const stringValue = toOptionalString(value);
     const metadata = stringValue
-      ? collection.getLabelRecordMetadata(stringValue)
+      ? await context.collections.getLabelRecordMetadata(
+          context.archive,
+          collection.id,
+          stringValue
+        )
       : undefined;
 
     if (!metadata) {

--- a/src/app/migrations/.snapshot-migrations.sqlite.json
+++ b/src/app/migrations/.snapshot-migrations.sqlite.json
@@ -43,9 +43,7 @@
       "name": "asset_collection",
       "indexes": [
         {
-          "columnNames": [
-            "parent_id"
-          ],
+          "columnNames": ["parent_id"],
           "composite": false,
           "keyName": "asset_collection_parent_id_index",
           "primary": false,
@@ -53,9 +51,7 @@
         },
         {
           "keyName": "primary",
-          "columnNames": [
-            "id"
-          ],
+          "columnNames": ["id"],
           "composite": false,
           "primary": true,
           "unique": true
@@ -65,13 +61,9 @@
       "foreignKeys": {
         "asset_collection_parent_id_foreign": {
           "constraintName": "asset_collection_parent_id_foreign",
-          "columnNames": [
-            "parent_id"
-          ],
+          "columnNames": ["parent_id"],
           "localTableName": "asset_collection",
-          "referencedColumnNames": [
-            "id"
-          ],
+          "referencedColumnNames": ["id"],
           "referencedTableName": "asset_collection",
           "deleteRule": "set null",
           "updateRule": "cascade"
@@ -136,9 +128,7 @@
       "name": "import_session",
       "indexes": [
         {
-          "columnNames": [
-            "target_collection_id"
-          ],
+          "columnNames": ["target_collection_id"],
           "composite": false,
           "keyName": "import_session_target_collection_id_index",
           "primary": false,
@@ -146,9 +136,7 @@
         },
         {
           "keyName": "primary",
-          "columnNames": [
-            "id"
-          ],
+          "columnNames": ["id"],
           "composite": false,
           "primary": true,
           "unique": true
@@ -158,13 +146,9 @@
       "foreignKeys": {
         "import_session_target_collection_id_foreign": {
           "constraintName": "import_session_target_collection_id_foreign",
-          "columnNames": [
-            "target_collection_id"
-          ],
+          "columnNames": ["target_collection_id"],
           "localTableName": "import_session",
-          "referencedColumnNames": [
-            "id"
-          ],
+          "referencedColumnNames": ["id"],
           "referencedTableName": "asset_collection",
           "updateRule": "cascade"
         }
@@ -237,9 +221,7 @@
       "name": "asset_import",
       "indexes": [
         {
-          "columnNames": [
-            "session_id"
-          ],
+          "columnNames": ["session_id"],
           "composite": false,
           "keyName": "asset_import_session_id_index",
           "primary": false,
@@ -247,9 +229,7 @@
         },
         {
           "keyName": "primary",
-          "columnNames": [
-            "id"
-          ],
+          "columnNames": ["id"],
           "composite": false,
           "primary": true,
           "unique": true
@@ -259,13 +239,9 @@
       "foreignKeys": {
         "asset_import_session_id_foreign": {
           "constraintName": "asset_import_session_id_foreign",
-          "columnNames": [
-            "session_id"
-          ],
+          "columnNames": ["session_id"],
           "localTableName": "asset_import",
-          "referencedColumnNames": [
-            "id"
-          ],
+          "referencedColumnNames": ["id"],
           "referencedTableName": "import_session",
           "deleteRule": "cascade",
           "updateRule": "cascade"
@@ -305,9 +281,7 @@
       "name": "asset",
       "indexes": [
         {
-          "columnNames": [
-            "collection_id"
-          ],
+          "columnNames": ["collection_id"],
           "composite": false,
           "keyName": "asset_collection_id_index",
           "primary": false,
@@ -315,9 +289,7 @@
         },
         {
           "keyName": "primary",
-          "columnNames": [
-            "id"
-          ],
+          "columnNames": ["id"],
           "composite": false,
           "primary": true,
           "unique": true
@@ -327,13 +299,9 @@
       "foreignKeys": {
         "asset_collection_id_foreign": {
           "constraintName": "asset_collection_id_foreign",
-          "columnNames": [
-            "collection_id"
-          ],
+          "columnNames": ["collection_id"],
           "localTableName": "asset",
-          "referencedColumnNames": [
-            "id"
-          ],
+          "referencedColumnNames": ["id"],
           "referencedTableName": "asset_collection",
           "updateRule": "cascade"
         }
@@ -381,9 +349,7 @@
       "name": "media_file",
       "indexes": [
         {
-          "columnNames": [
-            "asset_id"
-          ],
+          "columnNames": ["asset_id"],
           "composite": false,
           "keyName": "media_file_asset_id_index",
           "primary": false,
@@ -391,9 +357,7 @@
         },
         {
           "keyName": "primary",
-          "columnNames": [
-            "id"
-          ],
+          "columnNames": ["id"],
           "composite": false,
           "primary": true,
           "unique": true
@@ -403,13 +367,9 @@
       "foreignKeys": {
         "media_file_asset_id_foreign": {
           "constraintName": "media_file_asset_id_foreign",
-          "columnNames": [
-            "asset_id"
-          ],
+          "columnNames": ["asset_id"],
           "localTableName": "media_file",
-          "referencedColumnNames": [
-            "id"
-          ],
+          "referencedColumnNames": ["id"],
           "referencedTableName": "asset",
           "deleteRule": "set null",
           "updateRule": "cascade"
@@ -472,18 +432,14 @@
       "name": "file_import",
       "indexes": [
         {
-          "columnNames": [
-            "asset_id"
-          ],
+          "columnNames": ["asset_id"],
           "composite": false,
           "keyName": "file_import_asset_id_index",
           "primary": false,
           "unique": false
         },
         {
-          "columnNames": [
-            "media_id"
-          ],
+          "columnNames": ["media_id"],
           "composite": false,
           "keyName": "file_import_media_id_index",
           "primary": false,
@@ -491,9 +447,7 @@
         },
         {
           "keyName": "primary",
-          "columnNames": [
-            "id"
-          ],
+          "columnNames": ["id"],
           "composite": false,
           "primary": true,
           "unique": true
@@ -503,26 +457,18 @@
       "foreignKeys": {
         "file_import_asset_id_foreign": {
           "constraintName": "file_import_asset_id_foreign",
-          "columnNames": [
-            "asset_id"
-          ],
+          "columnNames": ["asset_id"],
           "localTableName": "file_import",
-          "referencedColumnNames": [
-            "id"
-          ],
+          "referencedColumnNames": ["id"],
           "referencedTableName": "asset_import",
           "deleteRule": "cascade",
           "updateRule": "cascade"
         },
         "file_import_media_id_foreign": {
           "constraintName": "file_import_media_id_foreign",
-          "columnNames": [
-            "media_id"
-          ],
+          "columnNames": ["media_id"],
           "localTableName": "file_import",
-          "referencedColumnNames": [
-            "id"
-          ],
+          "referencedColumnNames": ["id"],
           "referencedTableName": "media_file",
           "deleteRule": "set null",
           "updateRule": "cascade"

--- a/src/app/migrations/Migration20220325122538.ts
+++ b/src/app/migrations/Migration20220325122538.ts
@@ -1,24 +1,44 @@
 import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20220325122538 extends Migration {
-
   async up(): Promise<void> {
-    this.addSql('create table `import_session` (`id` text not null, `base_path` text not null, `phase` text check (`phase` in (\'READ_METADATA\', \'READ_FILES\', \'COMPLETED\', \'ERROR\')) not null, primary key (`id`));');
+    this.addSql(
+      "create table `import_session` (`id` text not null, `base_path` text not null, `phase` text check (`phase` in ('READ_METADATA', 'READ_FILES', 'COMPLETED', 'ERROR')) not null, primary key (`id`));"
+    );
 
-    this.addSql('create table `asset_import` (`id` text not null, `path` text not null, `session_id` text not null, `metadata` json not null, `phase` text check (`phase` in (\'READ_METADATA\', \'READ_FILES\', \'COMPLETED\', \'ERROR\')) not null, constraint `asset_import_session_id_foreign` foreign key(`session_id`) references `import_session`(`id`) on delete cascade on update cascade, primary key (`id`));');
-    this.addSql('create index `asset_import_session_id_index` on `asset_import` (`session_id`);');
+    this.addSql(
+      "create table `asset_import` (`id` text not null, `path` text not null, `session_id` text not null, `metadata` json not null, `phase` text check (`phase` in ('READ_METADATA', 'READ_FILES', 'COMPLETED', 'ERROR')) not null, constraint `asset_import_session_id_foreign` foreign key(`session_id`) references `import_session`(`id`) on delete cascade on update cascade, primary key (`id`));"
+    );
+    this.addSql(
+      'create index `asset_import_session_id_index` on `asset_import` (`session_id`);'
+    );
 
-    this.addSql('create table `asset` (`id` text not null, primary key (`id`));');
+    this.addSql(
+      'create table `asset` (`id` text not null, primary key (`id`));'
+    );
 
-    this.addSql('create table `asset_string_property` (`id` text not null, `key` text not null, `value` text not null, `asset_id` text not null, constraint `asset_string_property_asset_id_foreign` foreign key(`asset_id`) references `asset`(`id`) on delete cascade on update cascade, primary key (`id`));');
-    this.addSql('create index `asset_string_property_asset_id_index` on `asset_string_property` (`asset_id`);');
+    this.addSql(
+      'create table `asset_string_property` (`id` text not null, `key` text not null, `value` text not null, `asset_id` text not null, constraint `asset_string_property_asset_id_foreign` foreign key(`asset_id`) references `asset`(`id`) on delete cascade on update cascade, primary key (`id`));'
+    );
+    this.addSql(
+      'create index `asset_string_property_asset_id_index` on `asset_string_property` (`asset_id`);'
+    );
 
-    this.addSql('create table `media_file` (`id` text not null, `sha256` text not null, `mime_type` text not null, `asset_id` text null, constraint `media_file_asset_id_foreign` foreign key(`asset_id`) references `asset`(`id`) on delete set null on update cascade, primary key (`id`));');
-    this.addSql('create index `media_file_asset_id_index` on `media_file` (`asset_id`);');
+    this.addSql(
+      'create table `media_file` (`id` text not null, `sha256` text not null, `mime_type` text not null, `asset_id` text null, constraint `media_file_asset_id_foreign` foreign key(`asset_id`) references `asset`(`id`) on delete set null on update cascade, primary key (`id`));'
+    );
+    this.addSql(
+      'create index `media_file_asset_id_index` on `media_file` (`asset_id`);'
+    );
 
-    this.addSql('create table `file_import` (`id` text not null, `path` text not null, `asset_id` text not null, `media_id` text null, `error` text check (`error` in (\'UNSUPPORTED_MEDIA_TYPE\', \'IO_ERROR\', \'UNEXPECTED_ERROR\')) null, constraint `file_import_asset_id_foreign` foreign key(`asset_id`) references `asset_import`(`id`) on delete cascade on update cascade, constraint `file_import_media_id_foreign` foreign key(`media_id`) references `media_file`(`id`) on delete set null on update cascade, primary key (`id`));');
-    this.addSql('create index `file_import_asset_id_index` on `file_import` (`asset_id`);');
-    this.addSql('create index `file_import_media_id_index` on `file_import` (`media_id`);');
+    this.addSql(
+      "create table `file_import` (`id` text not null, `path` text not null, `asset_id` text not null, `media_id` text null, `error` text check (`error` in ('UNSUPPORTED_MEDIA_TYPE', 'IO_ERROR', 'UNEXPECTED_ERROR')) null, constraint `file_import_asset_id_foreign` foreign key(`asset_id`) references `asset_import`(`id`) on delete cascade on update cascade, constraint `file_import_media_id_foreign` foreign key(`media_id`) references `media_file`(`id`) on delete set null on update cascade, primary key (`id`));"
+    );
+    this.addSql(
+      'create index `file_import_asset_id_index` on `file_import` (`asset_id`);'
+    );
+    this.addSql(
+      'create index `file_import_media_id_index` on `file_import` (`media_id`);'
+    );
   }
-
 }

--- a/src/app/migrations/Migration20220330163941.ts
+++ b/src/app/migrations/Migration20220330163941.ts
@@ -1,12 +1,16 @@
 import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20220330163941 extends Migration {
-
   async up(): Promise<void> {
-    this.addSql('create table `asset_collection` (`id` text not null, `schema` json not null, primary key (`id`));');
+    this.addSql(
+      'create table `asset_collection` (`id` text not null, `schema` json not null, primary key (`id`));'
+    );
 
-    this.addSql('alter table `asset` add column `collection_id` text not null constraint asset_collection_id_foreign references `asset_collection` (`id`) on update cascade;');
-    this.addSql('create index `asset_collection_id_index` on `asset` (`collection_id`);');
+    this.addSql(
+      'alter table `asset` add column `collection_id` text not null constraint asset_collection_id_foreign references `asset_collection` (`id`) on update cascade;'
+    );
+    this.addSql(
+      'create index `asset_collection_id_index` on `asset` (`collection_id`);'
+    );
   }
-
 }

--- a/src/app/migrations/Migration20220331085930.ts
+++ b/src/app/migrations/Migration20220331085930.ts
@@ -1,9 +1,7 @@
 import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20220331085930 extends Migration {
-
   async up(): Promise<void> {
     this.addSql('alter table `asset` add column `metadata` json not null;');
   }
-
 }

--- a/src/app/migrations/Migration20220615145100.ts
+++ b/src/app/migrations/Migration20220615145100.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+import { randomUUID } from 'crypto';
+
+export class Migration20220523155306 extends Migration {
+  async up(): Promise<void> {
+    const collectionUuid = randomUUID();
+
+    this.addSql(
+      `insert into asset_collection (id, schema, title, parent_id) select '${collectionUuid}', schema, 'Main Collection', id from asset_collection where id = '$root'`
+    );
+    this.addSql(
+      `update asset set collection_id = '${collectionUuid}' where collection_id = '$root'`
+    );
+  }
+}

--- a/src/app/migrations/Migration20220615145100.ts
+++ b/src/app/migrations/Migration20220615145100.ts
@@ -6,7 +6,7 @@ export class Migration20220523155306 extends Migration {
     const collectionUuid = randomUUID();
 
     this.addSql(
-      `insert into asset_collection (id, schema, title, parent_id) select '${collectionUuid}', schema, 'Main Collection', id from asset_collection where id = '$root'`
+      `insert into asset_collection (id, schema, title, parent_id) select '${collectionUuid}', null, 'Main Collection', id from asset_collection where id = '$root'`
     );
     this.addSql(
       `update asset set collection_id = '${collectionUuid}' where collection_id = '$root'`

--- a/src/common/asset.interfaces.ts
+++ b/src/common/asset.interfaces.ts
@@ -323,6 +323,32 @@ export const DeleteAssets = RpcInterface({
 });
 
 /**
+ * Validate moving one or more assets to another collection.
+ */
+export const ValidateMoveAssets = RpcInterface({
+  id: 'assets/validate-move',
+  request: z.object({
+    assetIds: z.array(z.string()),
+    targetCollectionId: z.string()
+  }),
+  response: z.object({}),
+  error: z.nativeEnum(FetchError).or(AggregatedValidationError)
+});
+
+/**
+ * Delete one or more assets.
+ */
+export const MoveAssets = RpcInterface({
+  id: 'assets/move',
+  request: z.object({
+    assetIds: z.array(z.string()),
+    targetCollectionId: z.string()
+  }),
+  response: z.object({}),
+  error: z.nativeEnum(FetchError).or(ReferentialIntegrityError)
+});
+
+/**
  * Update the metadata for an asset.
  *
  * Performs a full update – missing keys are treated as setting the metadata value to null.

--- a/src/frontend/app.tsx
+++ b/src/frontend/app.tsx
@@ -2,6 +2,8 @@
 
 import { FC } from 'react';
 import { Route, Routes } from 'react-router-dom';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import { ArchiveScreen } from './screens/archive.screen';
 import { AssetDetailScreen } from './screens/asset-detail.sceen';
@@ -15,35 +17,37 @@ import { InvalidateOnPageChange } from './ui/components/util.component';
  * Root component for a window representing an archive
  */
 export const ArchiveWindow: FC<{ title?: string }> = ({ title }) => (
-  <Routes>
-    <Route path="/create-asset" element={<CreateAssetScreen />} />
-    <Route path="/asset-detail" element={<AssetDetailScreen />} />
-    <Route path="/" element={<ArchiveScreen title={title} />}>
-      <Route index element={<></>} />
-      <Route
-        path="ingest/:sessionId"
-        element={
-          <InvalidateOnPageChange>
-            <ArchiveIngestScreen />
-          </InvalidateOnPageChange>
-        }
-      />
-      <Route
-        path="collection/:collectionId/schema"
-        element={
-          <InvalidateOnPageChange>
-            <SchemaScreen />
-          </InvalidateOnPageChange>
-        }
-      />
-      <Route
-        path="collection/:collectionId"
-        element={
-          <InvalidateOnPageChange>
-            <CollectionScreen />
-          </InvalidateOnPageChange>
-        }
-      />
-    </Route>
-  </Routes>
+  <DndProvider backend={HTML5Backend}>
+    <Routes>
+      <Route path="/create-asset" element={<CreateAssetScreen />} />
+      <Route path="/asset-detail" element={<AssetDetailScreen />} />
+      <Route path="/" element={<ArchiveScreen title={title} />}>
+        <Route index element={<></>} />
+        <Route
+          path="ingest/:sessionId"
+          element={
+            <InvalidateOnPageChange>
+              <ArchiveIngestScreen />
+            </InvalidateOnPageChange>
+          }
+        />
+        <Route
+          path="collection/:collectionId/schema"
+          element={
+            <InvalidateOnPageChange>
+              <SchemaScreen />
+            </InvalidateOnPageChange>
+          }
+        />
+        <Route
+          path="collection/:collectionId"
+          element={
+            <InvalidateOnPageChange>
+              <CollectionScreen />
+            </InvalidateOnPageChange>
+          }
+        />
+      </Route>
+    </Routes>
+  </DndProvider>
 );

--- a/src/frontend/screens/archive.screen.tsx
+++ b/src/frontend/screens/archive.screen.tsx
@@ -3,7 +3,7 @@
 import { FC } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { Plus } from 'react-bootstrap-icons';
-import { Box, Flex, IconButton, Text } from 'theme-ui';
+import { Box, Flex, IconButton } from 'theme-ui';
 
 import {
   ExportCollection,
@@ -21,35 +21,28 @@ import {
   NavListSection,
   ArchiveWindowLayout
 } from '../ui/components/page-layouts.component';
-import { WindowDragArea, WindowInset, WindowTitle } from '../ui/window';
+import { WindowInset, WindowTitle } from '../ui/window';
 import { useContextMenu } from '../ui/hooks/menu.hooks';
 import {
   CreateCollection,
   defaultSchemaProperty,
   GetRootAssetsCollection,
   GetRootDatabaseCollection,
-  GetSubcollections,
   UpdateCollection
 } from '../../common/asset.interfaces';
 import { useErrorDisplay } from '../ui/hooks/error.hooks';
-import { useFrontendConfig } from '../config';
+import { CollectionBrowser } from '../ui/components/collection-browser.component';
 
 /**
  * The wrapper component for an archive window. Shows the screen's top-level navigation and renders the active route.
  */
 export const ArchiveScreen: FC<{ title?: string }> = ({ title }) => {
   const imports = useListAll(ListIngestSession, () => ({}), []);
-  const config = useFrontendConfig();
   const rpc = useRPC();
-  const assetRoot = unwrapGetResult(useGet(GetRootAssetsCollection));
   const navigate = useNavigate();
 
+  const assetRoot = unwrapGetResult(useGet(GetRootAssetsCollection));
   const databaseRoot = unwrapGetResult(useGet(GetRootDatabaseCollection));
-  const databases = useListAll(
-    GetSubcollections,
-    () => (databaseRoot ? { parent: databaseRoot.id } : 'skip'),
-    [databaseRoot]
-  );
 
   const createMenu = useCreateMenu();
   const renameCollection = async (id: string, title: string) => {
@@ -68,7 +61,7 @@ export const ArchiveScreen: FC<{ title?: string }> = ({ title }) => {
     await rpc(ExportCollection, { collectionId });
   };
 
-  if (!assetRoot) {
+  if (!assetRoot || !databaseRoot) {
     return null;
   }
 
@@ -95,49 +88,47 @@ export const ArchiveScreen: FC<{ title?: string }> = ({ title }) => {
 
             {/* Assets */}
             <NavListSection title="Collections">
-              <NavListItem
-                title="Main Collection"
-                path={`/collection/${assetRoot.id}`}
-                contextMenuItems={[
-                  {
-                    action: () => startImport(assetRoot.id),
-                    id: 'start-import',
-                    label: 'Import assets'
-                  },
-                  {
-                    action: () => startExport(assetRoot.id),
-                    id: 'start-export',
-                    label: 'Export assets'
-                  }
-                ]}
+              <CollectionBrowser
+                parentId={assetRoot.id}
+                itemProps={(collection) => ({
+                  onRename: (title) => renameCollection(collection.id, title),
+                  contextMenuItems: [
+                    {
+                      action: () => startImport(assetRoot.id),
+                      id: 'start-import',
+                      label: 'Import assets'
+                    },
+                    {
+                      action: () => startExport(assetRoot.id),
+                      id: 'start-export',
+                      label: 'Export assets'
+                    }
+                  ]
+                })}
               />
             </NavListSection>
 
             {/* Databases */}
-            {renderIfPresent(databases, (databases) => (
-              <NavListSection title="Databases">
-                {databases.map((db) => (
-                  <NavListItem
-                    key={db.id}
-                    title={db.title}
-                    path={`/collection/${db.id}`}
-                    onRename={(title) => renameCollection(db.id, title)}
-                    contextMenuItems={[
-                      {
-                        action: () => startImport(db.id),
-                        id: 'start-import',
-                        label: 'Import database records'
-                      },
-                      {
-                        action: () => startExport(db.id),
-                        id: 'start-export',
-                        label: 'Export database'
-                      }
-                    ]}
-                  />
-                ))}
-              </NavListSection>
-            ))}
+            <NavListSection title="Databases">
+              <CollectionBrowser
+                parentId={databaseRoot.id}
+                itemProps={(collection) => ({
+                  onRename: (title) => renameCollection(collection.id, title),
+                  contextMenuItems: [
+                    {
+                      action: () => startImport(collection.id),
+                      id: 'start-import',
+                      label: 'Import database records'
+                    },
+                    {
+                      action: () => startExport(collection.id),
+                      id: 'start-export',
+                      label: 'Export database'
+                    }
+                  ]
+                })}
+              />
+            </NavListSection>
           </Box>
         </>
       }

--- a/src/frontend/screens/collection.screen.tsx
+++ b/src/frontend/screens/collection.screen.tsx
@@ -4,8 +4,10 @@ import { FC, useCallback, useMemo } from 'react';
 import {
   Asset,
   AssetMetadata,
+  CollectionType,
   DeleteAssets,
   GetCollection,
+  GetRootAssetsCollection,
   ListAssets,
   SchemaProperty
 } from '../../common/asset.interfaces';
@@ -45,6 +47,7 @@ export const CollectionScreen: FC = () => {
     'Expected collectionId param'
   );
   const collection = unwrapGetResult(useGet(GetCollection, collectionId));
+  const rootAssetsCollection = unwrapGetResult(useGet(GetRootAssetsCollection));
   const assets = useList(
     ListAssets,
     () => (collection ? { collectionId: collection.id } : 'skip'),
@@ -56,13 +59,29 @@ export const CollectionScreen: FC = () => {
   const configMenu = useContextMenu({
     on: 'click',
     options: [
-      {
-        id: 'editSchema',
-        label: 'Edit Schema',
-        action: () => {
-          navigate(`/collection/${collectionId}/schema`);
+      collection &&
+        rootAssetsCollection && {
+          id: 'editSchema',
+          label: 'Edit Schema',
+          action: () => {
+            /**
+             * We currently only expose to users the ability to maintain a single schema for
+             * asset collections as we haven't implemented a UI that reflects schema inheritance.
+             *
+             * Edits to asset collection schemas are therefore done on the root collection, which get
+             * picked up by child collections via inheritance.
+             *
+             * We solve this differently for controlled databases – we instead don't expose the ability to create
+             * 'subcollections' of controlled databases. Controlled databases have a flat structure, so immediate
+             * children of the root controlled database get their own schema.
+             */
+            if (collection.type === CollectionType.CONTROLLED_DATABASE) {
+              navigate(`/collection/${collectionId}/schema`);
+            } else {
+              navigate(`/collection/${rootAssetsCollection.id}/schema`);
+            }
+          }
         }
-      }
     ]
   });
 

--- a/src/frontend/screens/collection.screen.tsx
+++ b/src/frontend/screens/collection.screen.tsx
@@ -136,6 +136,7 @@ export const CollectionScreen: FC = () => {
           data={assets}
           contextMenuItems={assetContextMenu}
           onDoubleClickItem={assetOps.openDetailView}
+          dragConfig={(asset) => ({ type: 'asset', id: asset.id })}
         />
 
         <BottomBar

--- a/src/frontend/ui/components/collection-browser.component.tsx
+++ b/src/frontend/ui/components/collection-browser.component.tsx
@@ -1,0 +1,38 @@
+import { FC } from 'react';
+import {
+  Collection,
+  GetSubcollections
+} from '../../../common/asset.interfaces';
+import { unwrapGetResult, useListAll } from '../../ipc/ipc.hooks';
+import { NavListItem, NavListItemProps } from './page-layouts.component';
+
+interface CollectionBrowserProps {
+  parentId: string;
+  itemProps?: (item: Collection) => Partial<NavListItemProps>;
+}
+
+export const CollectionBrowser: FC<CollectionBrowserProps> = ({
+  parentId,
+  itemProps
+}) => {
+  const assetCollections = unwrapGetResult(
+    useListAll(GetSubcollections, () => ({ parent: parentId }), [parentId])
+  );
+
+  if (!assetCollections) {
+    return null;
+  }
+
+  return (
+    <>
+      {assetCollections.map((collection) => (
+        <NavListItem
+          key={collection.id}
+          title={collection.title}
+          path={`/collection/${collection.id}`}
+          {...itemProps?.(collection)}
+        />
+      ))}
+    </>
+  );
+};

--- a/src/frontend/ui/components/dnd.component.tsx
+++ b/src/frontend/ui/components/dnd.component.tsx
@@ -1,0 +1,129 @@
+import {
+  cloneElement,
+  FC,
+  ReactElement,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+import { useDrag, useDragDropManager, useDrop } from 'react-dnd';
+import { Result } from '../../../common/util/error';
+import { Scheduler } from '../../../common/util/scheduler';
+import { Dict } from '../../../common/util/types';
+
+interface DraggableProps {
+  children?: ReactElement;
+  type: string;
+  id: string;
+}
+
+export interface DragItem {
+  id: string;
+}
+
+export const Draggable: FC<DraggableProps> = ({ children, type, id }) => {
+  const [collected, drag, dragPreview] = useDrag<DragItem>(() => ({
+    type,
+    item: { id }
+  }));
+
+  if (!children) {
+    return null;
+  }
+
+  return cloneElement(children, { ref: drag });
+};
+
+interface DropTargetProps {
+  children?: ReactElement;
+  types: Record<string, DropSpec>;
+}
+
+export interface DropTargetChildProps {
+  dropAccepted?: boolean;
+}
+
+export interface DropSpec {
+  validateDrop?: (id: string) => Promise<boolean>;
+  accept: (id: string) => Promise<Result>;
+}
+
+export const DropTarget: FC<DropTargetProps> = ({ children, types }) => {
+  const dnd = useDragDropManager();
+  const [accepted, setAccepted] = useState<Dict<boolean>>({});
+  const scheduler = useMemo(() => new Scheduler(), []);
+
+  useEffect(() => {
+    const monitor = dnd.getMonitor();
+
+    return monitor.subscribeToStateChange(() => {
+      if (!monitor.isDragging()) {
+        setAccepted({});
+      }
+    });
+  }, [dnd]);
+
+  const [state, drop] = useDrop(
+    () => ({
+      accept: Object.keys(types),
+
+      drop: async (item: DragItem, monitor) => {
+        const type = monitor.getItemType();
+        const spec = type && types[String(type)];
+        if (!spec) {
+          return;
+        }
+
+        scheduler.run(async () => {
+          if (accepted[item.id] === false) {
+            return;
+          }
+
+          const shouldAccept = spec.validateDrop
+            ? await spec.validateDrop(item.id)
+            : true;
+
+          if (shouldAccept) {
+            await spec.accept(item.id);
+          }
+        });
+      },
+
+      hover: (item, monitor) => {
+        if (item.id in accepted) {
+          return;
+        }
+
+        const type = monitor.getItemType();
+        const spec = type && types[String(type)];
+        if (!spec) {
+          return;
+        }
+
+        scheduler.run(async () => {
+          const ok = spec.validateDrop
+            ? await spec.validateDrop(item.id)
+            : true;
+          setAccepted((prev) => ({ ...prev, [item.id]: ok }));
+        });
+      },
+
+      collect: (monitor) => {
+        const item = monitor.getItem();
+        return {
+          id: item ? item.id : undefined,
+          active: !!item && monitor.isOver()
+        };
+      }
+    }),
+    [accepted]
+  );
+
+  const ok = state.active && state.id && accepted[state.id];
+
+  if (!children) {
+    return null;
+  }
+
+  return cloneElement(children, { ref: drop, dropAccepted: !!ok });
+};

--- a/src/frontend/ui/components/page-layouts.component.tsx
+++ b/src/frontend/ui/components/page-layouts.component.tsx
@@ -44,7 +44,7 @@ export const NavListSection: FC<NavListSectionProps> = ({
   </Box>
 );
 
-interface NavListItemProps {
+export interface NavListItemProps {
   /** Label presented to user */
   title: string;
 

--- a/src/frontend/ui/components/page-layouts.component.tsx
+++ b/src/frontend/ui/components/page-layouts.component.tsx
@@ -6,6 +6,7 @@ import {
   FC,
   FocusEvent,
   FormEvent,
+  forwardRef,
   ReactElement,
   ReactNode,
   useCallback,
@@ -21,6 +22,8 @@ import {
   useContextMenu
 } from '../hooks/menu.hooks';
 import { useOnClickOutside } from '../hooks/mouse.hooks';
+import { DropTargetChildProps } from './dnd.component';
+import { useMergedRefs } from '../hooks/state.hooks';
 
 interface NavListSectionProps {
   /** Section header presented to user */
@@ -44,7 +47,7 @@ export const NavListSection: FC<NavListSectionProps> = ({
   </Box>
 );
 
-export interface NavListItemProps {
+export interface NavListItemProps extends DropTargetChildProps {
   /** Label presented to user */
   title: string;
 
@@ -69,159 +72,167 @@ export interface NavListItemProps {
 /**
  * Link item in a top-level navigation list. Renders active state.
  */
-export const NavListItem: FC<NavListItemProps> = ({
-  path,
-  title: label,
-  defaultEditing = false,
-  onRename,
-  onDelete,
-  status,
-  contextMenuItems = [],
-  ...props
-}) => {
-  const isActive = useLocation().pathname === path;
-  const [editing, setEditing] = useState(defaultEditing);
-  const wrapperRef = useRef<HTMLDivElement | null>(null);
-  const contextMenu = useContextMenu({
-    options: [
-      onRename && {
-        id: 'rename',
-        label: 'Rename',
-        action: () => {
-          setEditing(true);
+export const NavListItem: FC<NavListItemProps> = forwardRef(
+  (
+    {
+      path,
+      title: label,
+      defaultEditing = false,
+      onRename,
+      onDelete,
+      status,
+      contextMenuItems = [],
+      dropAccepted,
+      ...props
+    },
+    ref
+  ) => {
+    const isActive = useLocation().pathname === path;
+    const [editing, setEditing] = useState(defaultEditing);
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
+    const contextMenu = useContextMenu({
+      options: [
+        onRename && {
+          id: 'rename',
+          label: 'Rename',
+          action: () => {
+            setEditing(true);
+          }
+        },
+        onDelete && {
+          id: 'delete',
+          label: 'Delete',
+          action: onDelete
+        },
+        ...(contextMenuItems.length > 0
+          ? [ContextSeparator, ...contextMenuItems]
+          : [])
+      ]
+    });
+
+    const finishEditing = useCallback(
+      async (el: HTMLInputElement) => {
+        if (el && onRename && el.value.trim() && el.value.trim() !== label) {
+          await onRename(el.value);
+
+          // Ugly hack: Prevent old value from flickering back in
+          await new Promise((resolve) => setTimeout(resolve, 250));
         }
+        setEditing(false);
       },
-      onDelete && {
-        id: 'delete',
-        label: 'Delete',
-        action: onDelete
-      },
-      ...(contextMenuItems.length > 0
-        ? [ContextSeparator, ...contextMenuItems]
-        : [])
-    ]
-  });
-
-  const finishEditing = useCallback(
-    async (el: HTMLInputElement) => {
-      if (el && onRename && el.value.trim() && el.value.trim() !== label) {
-        await onRename(el.value);
-
-        // Ugly hack: Prevent old value from flickering back in
-        await new Promise((resolve) => setTimeout(resolve, 250));
-      }
-      setEditing(false);
-    },
-    [label, onRename]
-  );
-
-  const handleSubmit = useCallback(
-    async (event: FormEvent<HTMLElement>) => {
-      event.preventDefault();
-      const el = event.currentTarget.querySelector<HTMLInputElement>(
-        'input[name="value"]'
-      );
-
-      if (el) {
-        finishEditing(el);
-      }
-    },
-    [finishEditing]
-  );
-
-  const handleBlur = useCallback(
-    async (event: FocusEvent<HTMLInputElement>) => {
-      finishEditing(event.currentTarget);
-    },
-    [finishEditing]
-  );
-
-  useOnClickOutside(wrapperRef, () => {
-    if (editing && wrapperRef.current) {
-      const input = wrapperRef.current.querySelector<HTMLInputElement>(
-        'input[name="value"]'
-      );
-      if (input) {
-        finishEditing(input);
-      }
-    }
-  });
-
-  const content = (
-    <Flex
-      {...contextMenu.triggerProps}
-      ref={wrapperRef}
-      tabIndex={0}
-      sx={{
-        variant:
-          !isActive && (editing || contextMenu.visible)
-            ? 'listItems.active'
-            : undefined,
-        flexDirection: 'row',
-        alignItems: 'center',
-        bg: isActive ? 'highlight' : undefined,
-        p: 2,
-        px: 3,
-        fontSize: 1,
-        marginTop: '1px',
-        color: isActive ? 'highlightContrast' : undefined,
-        '&:hover': {
-          bg: isActive ? undefined : 'highlightHint'
-        }
-      }}
-      {...props}
-    >
-      {!editing && (
-        <span tabIndex={-1} sx={{ flex: 1 }}>
-          {label}
-        </span>
-      )}
-
-      {editing && (
-        <form onSubmit={handleSubmit}>
-          <input
-            ref={focusOnMount}
-            onBlur={handleBlur}
-            name="value"
-            sx={{
-              flex: 1,
-              p: 0,
-              border: 'none',
-              outline: 'none',
-              bg: 'transparent',
-              letterSpacing: 'inherit',
-              fontSize: 'inherit',
-              fontFamily: 'inherit',
-              fontWeight: 'inherit',
-              color: isActive ? 'highlightContrast' : 'text'
-            }}
-            defaultValue={label}
-          />
-        </form>
-      )}
-
-      {status}
-    </Flex>
-  );
-
-  if (editing) {
-    return (
-      <span sx={{ color: 'inherit', textDecoration: 'inherit' }} {...props}>
-        {content}
-      </span>
+      [label, onRename]
     );
-  } else {
-    return (
-      <NavLink
-        sx={{ color: 'inherit', textDecoration: 'inherit' }}
-        to={path}
+
+    const handleSubmit = useCallback(
+      async (event: FormEvent<HTMLElement>) => {
+        event.preventDefault();
+        const el = event.currentTarget.querySelector<HTMLInputElement>(
+          'input[name="value"]'
+        );
+
+        if (el) {
+          finishEditing(el);
+        }
+      },
+      [finishEditing]
+    );
+
+    const handleBlur = useCallback(
+      async (event: FocusEvent<HTMLInputElement>) => {
+        finishEditing(event.currentTarget);
+      },
+      [finishEditing]
+    );
+
+    useOnClickOutside(wrapperRef, () => {
+      if (editing && wrapperRef.current) {
+        const input = wrapperRef.current.querySelector<HTMLInputElement>(
+          'input[name="value"]'
+        );
+        if (input) {
+          finishEditing(input);
+        }
+      }
+    });
+
+    const refs = useMergedRefs(ref, wrapperRef);
+
+    const content = (
+      <Flex
+        {...contextMenu.triggerProps}
+        ref={refs}
+        tabIndex={0}
+        sx={{
+          variant:
+            (!isActive && (editing || contextMenu.visible)) || dropAccepted
+              ? 'listItems.active'
+              : undefined,
+          flexDirection: 'row',
+          alignItems: 'center',
+          bg: isActive ? 'highlight' : undefined,
+          p: 2,
+          px: 3,
+          fontSize: 1,
+          marginTop: '1px',
+          color: isActive ? 'highlightContrast' : undefined,
+          '&:hover': {
+            bg: isActive ? undefined : 'highlightHint'
+          }
+        }}
         {...props}
       >
-        {content}
-      </NavLink>
+        {!editing && (
+          <span tabIndex={-1} sx={{ flex: 1 }}>
+            {label}
+          </span>
+        )}
+
+        {editing && (
+          <form onSubmit={handleSubmit}>
+            <input
+              ref={focusOnMount}
+              onBlur={handleBlur}
+              name="value"
+              sx={{
+                flex: 1,
+                p: 0,
+                border: 'none',
+                outline: 'none',
+                bg: 'transparent',
+                letterSpacing: 'inherit',
+                fontSize: 'inherit',
+                fontFamily: 'inherit',
+                fontWeight: 'inherit',
+                color: isActive ? 'highlightContrast' : 'text'
+              }}
+              defaultValue={label}
+            />
+          </form>
+        )}
+
+        {status}
+      </Flex>
     );
+
+    if (editing) {
+      return (
+        <span sx={{ color: 'inherit', textDecoration: 'inherit' }} {...props}>
+          {content}
+        </span>
+      );
+    } else {
+      return (
+        <NavLink
+          sx={{ color: 'inherit', textDecoration: 'inherit' }}
+          to={path}
+          {...props}
+        >
+          {content}
+        </NavLink>
+      );
+    }
   }
-};
+);
 
 export interface ArchiveWindowLayoutProps {
   /** Top-level navigation view */

--- a/src/frontend/ui/hooks/state.hooks.ts
+++ b/src/frontend/ui/hooks/state.hooks.ts
@@ -1,5 +1,5 @@
 import EventEmitter from 'eventemitter3';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, Ref, MutableRefObject } from 'react';
 
 /**
  * Listens to an eventemitter and tears down the subscription on unmount.
@@ -29,4 +29,16 @@ export function useEventEmitter<T extends unknown[], Key extends string>(
       genericEmitter.off(event, handle);
     };
   }, [genericEmitter, event]);
+}
+
+export function useMergedRefs<T>(...refs: (Ref<T> | undefined)[]) {
+  return (val: T) => {
+    for (const x of refs) {
+      if (typeof x === 'function') {
+        x(val);
+      } else if (x && typeof x === 'object') {
+        (x as MutableRefObject<T>).current = val;
+      }
+    }
+  };
 }

--- a/src/test/result.ts
+++ b/src/test/result.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { assert } from '../common/util/assert';
-import { ErrorResult, Result } from '../common/util/error';
+import { ErrorResult, OkResult, Result } from '../common/util/error';
 
 export function requireSuccess<T>(x: Result<T>) {
   assert(
@@ -13,7 +13,11 @@ export function requireSuccess<T>(x: Result<T>) {
 }
 
 export function requireFailure<T>(x: Result<unknown, T>) {
-  assert(x.status === 'error', 'Expected operation to fail. Got result:', x);
+  assert(
+    x.status === 'error',
+    'Expected operation to fail. Got result:',
+    (x as OkResult).value
+  );
 
   return x.error;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,6 +1157,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.9.2":
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
+  integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.7", "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -2021,6 +2028,21 @@
   version "2.11.5"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
   integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
+
+"@react-dnd/asap@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-5.0.2.tgz#1f81f124c1cd6f39511c11a881cfb0f715343488"
+  integrity sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==
+
+"@react-dnd/invariant@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-4.0.2.tgz#b92edffca10a26466643349fac7cdfb8799769df"
+  integrity sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==
+
+"@react-dnd/shallowequal@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz#d1b4befa423f692fa4abf1c79209702e7d8ae4b4"
+  integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
 
 "@rollup/pluginutils@^4.2.1":
   version "4.2.1"
@@ -6351,6 +6373,15 @@ dmg-license@^1.0.9:
     smart-buffer "^4.0.2"
     verror "^1.10.0"
 
+dnd-core@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-16.0.1.tgz#a1c213ed08961f6bd1959a28bb76f1a868360d19"
+  integrity sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==
+  dependencies:
+    "@react-dnd/asap" "^5.0.1"
+    "@react-dnd/invariant" "^4.0.1"
+    redux "^4.2.0"
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -8402,7 +8433,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -11970,6 +12001,24 @@ react-colorful@^5.1.2:
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.5.1.tgz#29d9c4e496f2ca784dd2bb5053a3a4340cfaf784"
   integrity sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==
 
+react-dnd-html5-backend@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz#87faef15845d512a23b3c08d29ecfd34871688b6"
+  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
+  dependencies:
+    dnd-core "^16.0.1"
+
+react-dnd@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-16.0.1.tgz#2442a3ec67892c60d40a1559eef45498ba26fa37"
+  integrity sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==
+  dependencies:
+    "@react-dnd/invariant" "^4.0.1"
+    "@react-dnd/shallowequal" "^4.0.1"
+    dnd-core "^16.0.1"
+    fast-deep-equal "^3.1.3"
+    hoist-non-react-statics "^3.3.2"
+
 react-docgen-typescript@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
@@ -12283,6 +12332,13 @@ rechoir@^0.8.0:
   integrity sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==
   dependencies:
     resolve "^1.20.0"
+
+redux@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
+  integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 reflect-metadata@0.1.13:
   version "0.1.13"


### PR DESCRIPTION
This PR adds support for multiple collections of assets. It also adds support for moving assets between collections.

![screen](https://user-images.githubusercontent.com/361391/174601597-f8308d7e-5647-45fd-841d-c93f46a8fad4.gif)
 
There's a slight complexity around supporting multiple collections (and particularly allowing assets to be moved between them) related to schemas.

In the current domain model, schemas are defined on a collection-level. This works well when there is just one collection of assets and many controlled databases. The schema of a controlled database differs to the schema of the asset collection. This is fine.

Introducing multiple collections of assets, we generally (and for most of our current users, always), want to share schemas between asset collections. In effect, the relationship between collections and schemas moves from being one-one to being many-one.

There are three ways this could be plausibly handled (this is fairly abstract, so please ask if I haven't explained it well):

1. Firstly, we could do this quite literally, and make schemas an object in their own right, related to collections, rather than being an attribute of collections.
2. Secondly, we could treat asset collections differently from controlled databases – controlled databases have their own schema, but assets all share a single, global schema. 
3. Thirdly, we could continue to treat schemas as attributes, but support schema inheritance. So, in a situation where we have multiiple collections, there may be a common schema that all collections have, but collections are able to add their own attributes on top of the parent collection.

The approach used in this PR is 2, with an aspiration to move towards 3 over time. This choice is made for a few reasons:

* Our current users have no requirement for multiple asset schemas.
* When we have sub-collections, a view into any non-leaf collection probably wants to view the assets in the subcollections. If in future we allow multiple asset schemas, we probably want to require that the subcollections of a given collection are polymorphic in order to support this.

Concretely, the way this is implemented in code is:

* There is a root asset collection, which contains no assets, only child collections. It defines a schema, which is inherited by all asset collections.
* There is a root database collection, which contains no records in itself, only child databases. It defines a schema, but that schema is empty (it has no properties).
* Asking to edit the schema of an asset collection is hardcoded to edit the root asset schema.
* There is no way exposed in the UI of editing any asset collection's schema other than the root.
* Asking to edit the schema of a controlled database is hardcoded to edit the schema of the selected database.
* Schemas are inherited by child collections – the schema used to determine display and validation is the result of adding to the parent collections the properties of the child collections (analagously to how class inheritance works in OO programming)

We validate moving assets between collections in the following way:

* Any asset may be moved between any collection
* Controlled database records may not be moved into another controlled database.
* Assets may not be moved into controlled databases, nor the other way round.

This gives us the ability to support multiple schemas in future, without having to do all the work for this now.

Limitations

The following are not implemented for now:

* Support for sub-collections. This will be a relatively simple, mostly ui-based feature that re-uses the infrastructure in this PR.
* Validation that an overriden property is compatible with the parent property. This is not required until we expose the ability to create sub-collections that refine their parent's schema.

Something we haven't even begun to address is how referential integrity is preserved when a record referenced elsewhere is moved to another collection. We skirt this by:

* Only allowing relationships when the target collection is a controlled database
* Not allowing records to be moved from controlled databases

This is fine for the forseeable future - the use case for moving records between collections is primarily categorising assets into subcollections.